### PR TITLE
Platform-agnostic auth: per-request credentials + inbound auth for mcp-server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,24 @@ Per toolset `<toolset>` (e.g. `jira`):
   purely so each action gets its own Hermes slash command; they contain
   no Python of their own and nothing to test.
 
+**`skills/_shared/`** holds code more than one toolset needs -- e.g.
+`credentials/http.py`'s `Credential`/`BasicCredential`/`BearerCredential`
+types, used identically by any toolset authenticating a `requests.Session`
+(Jira today). A toolset that needs one of these files **symlinks** it
+into its own `lib/` (`ln -s ../../_shared/credentials/http.py
+skills/jira/lib/credentials.py`) rather than copying it -- one edit
+updates every consumer. This works under both consumption paths this
+repo supports: a direct `git clone` preserves the symlink natively, and
+`npx skills add --skill <name>`'s own installer (`vercel-labs/skills`)
+copies a symlinked file with `dereference: true` specifically to handle
+exactly this case (confirmed by reading its actual source, not assumed).
+**`skills/_shared/` must never contain a `SKILL.md`** -- both consumers
+above discover skills by walking for `SKILL.md`'s presence, so a
+directory without one is structurally invisible to either, not just
+conventionally excluded; `mcp-server/tests/test_registry.py` asserts
+this stays true. See `skills/_shared/README.md` for the full explanation,
+including the Windows `core.symlinks` caveat.
+
 When changing behavior (auth, request handling, tool output shape) for
 a toolset, edit its `skills/<toolset>/lib/` or `skills/<toolset>/tools/`,
 then update `skills/<toolset>/tests/` and run:
@@ -133,7 +151,23 @@ this repo's frontmatter extends it.
 These apply repo-wide, to every toolset, not just Jira:
 
 - **Credentials only ever come from environment variables**, never
-  hard-coded, never logged in plaintext.
+  hard-coded, never logged in plaintext. A toolset's own code (its
+  `lib/auth.py`, its client) never knows or cares *how* an env var got
+  its value for a given process -- direct/personal use sets it once in
+  the shell; `mcp-server` may instead resolve it per request (a
+  multi-user client handing one caller's credential to one call and a
+  different caller's to the next), via a header-to-env override that's
+  opt-in and off by default -- see `mcp-server/README.md`'s "Multi-user
+  credentials and inbound auth". Either way the toolset still only ever
+  reads an env var; nothing about this convention or a toolset's own
+  code changes.
+- **A var that's genuinely a secret (a password, a token, an API key --
+  not a base URL or a boolean flag) sets `sensitive: true` on its
+  `required_environment_variables` entry.** This is what lets
+  `mcp-server` redact that var's resolved value from any error output a
+  caller (and therefore an LLM) sees -- see `skills/jira/SKILL.md`'s
+  `JIRA_PASSWORD`/`JIRA_PAT` entries for the pattern. A var without this
+  flag is assumed non-sensitive and is never redacted.
 - **No hardcoded local filesystem paths** in any `SKILL.md`, `README.md`,
   or Python source -- this repo is public. Use `../<toolset>/...`-relative
   paths or a generic `/path/to/...` placeholder in docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,33 @@ in the top-level `README.md`. See that file's "Agent Skills format"
 section for the open format this repo's `SKILL.md`s follow, and where
 this repo's frontmatter extends it.
 
+## Authentication
+
+Two independent layers, both real, don't conflate them:
+
+1. **A toolset's own credential** -- e.g. `skills/jira/lib/auth.py`'s
+   `load_credential()` returns a `Credential` (`BasicCredential` from
+   `JIRA_USERNAME`/`JIRA_PASSWORD`, or `BearerCredential` from `JIRA_PAT`
+   -- a Data Center Personal Access Token, an API key, or an OAuth token
+   all share this one wire format). This is the *only* layer that
+   exists for direct/personal use (Claude Code, Hermes, claude.ai) --
+   set the env vars, the toolset reads them, done.
+2. **`mcp-server`'s per-request resolution**, for a multi-user
+   deployment sharing one running server: a scoped environment per
+   subprocess call (never another toolset's credentials), an opt-in
+   per-request override (`X-Agent-Skills-Env-<VAR>`, trusted only
+   behind `--trust-request-credentials`), and opt-in inbound auth
+   (`MCP_AUTH_KEYCLOAK_REALM_URL`) to verify who's calling before that
+   trust means anything. Off by default; a toolset's own code never
+   knows or needs to know this layer exists.
+
+**[`AUTHENTICATION.md`](AUTHENTICATION.md)** is the full explanation of
+both -- read it before changing anything in `mcp-server/lib/credentials.py`,
+`mcp-server/lib/auth.py`, or any toolset's `lib/auth.py`. The
+`sensitive: true` and env-vars-only rules below are this layer's
+concrete, checkable conventions; the document above is the reasoning
+and the flow diagrams behind them.
+
 ## Conventions
 
 These apply repo-wide, to every toolset, not just Jira:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,12 @@ already knows the codebase. It complements, not replaces:
   agent) must follow when adding or changing a skill.
 - [`mcp-server/README.md`](mcp-server/README.md) -- operational detail
   for the MCP server specifically.
+- [`AUTHENTICATION.md`](AUTHENTICATION.md) -- the full credential and
+  auth story: a toolset's own env-based credential, `mcp-server`'s
+  per-request credential resolution for multi-user deployments, and
+  inbound auth. A *different* concern from this document's own
+  "Security model" section below (confirm-gating), covered there in
+  full because it's substantial enough to deserve its own document.
 
 ## Purpose
 
@@ -114,6 +120,14 @@ the failure mode the gate exists to catch:
 The MCP server does not add, remove, or weaken any of this -- a gated
 tool called over MCP behaves identically to the same tool called over a
 shell, because it's the same code, run the same way.
+
+**This is a different question from *which identity* a gated write
+executes as.** Confirm-gating decides whether a write happens at all;
+it says nothing about who it happens as, which is genuinely orthogonal
+-- both apply independently to the same write. See
+[`AUTHENTICATION.md`](AUTHENTICATION.md) for that: a toolset's own
+env-based credential for direct use, and `mcp-server`'s per-request
+credential resolution plus inbound auth for a multi-user deployment.
 
 ## Entities reference
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,657 @@
+# Authentication and credentials
+
+This document explains how credentials and authentication work across
+this whole repo -- for a toolset used directly (a skill on your own
+laptop) and for the same toolset served over MCP to a multi-user chat
+client. It's written for whoever maintains or extends this later,
+including a future you. It complements, not replaces:
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) -- the repo's overall shape and
+  its confirm-gate security model (a *different* concern from this
+  document: confirm-gating is about "should this write happen at all,"
+  this document is about "who is this write happening as").
+- [`AGENTS.md`](AGENTS.md) -- the concrete rules a contributor follows;
+  its "Conventions" section states the credential/`sensitive: true`
+  rules this document explains the reasoning behind.
+- [`mcp-server/README.md`](mcp-server/README.md) -- operational
+  reference for the server's flags and env vars specifically.
+- [`skills/jira/README.md`](skills/jira/README.md) -- Jira's own
+  concrete config table, as the first (and currently only) toolset
+  using everything described here.
+
+If you only read one thing, read "The one sentence version" and "Part 4:
+security properties" -- everything else is detail in service of those.
+
+---
+
+## The one sentence version
+
+**A toolset logs in with whatever credential it's handed, and never
+knows or cares where that credential came from** -- your own shell's
+environment variables when you run it yourself, or a specific caller's
+credential that `mcp-server` resolved just for that one request when
+it's serving many different people through one running server.
+
+---
+
+## Why this exists (plain English)
+
+Every toolset in this repo -- Jira today, more later -- needs to log
+into some real system. The obvious way is environment variables:
+`JIRA_USERNAME`, `JIRA_PASSWORD`. That's simple, it's genuinely correct
+for one person running one script on their own machine, and it's the
+approach this repo started with.
+
+It breaks down the moment the *same running server* serves *many
+different people*. Picture `mcp-server` sitting behind a chat app like
+LibreChat, with Alice and Bob both typing requests into the same chat
+interface. If the server's Jira credential is one fixed environment
+variable, then every action -- Alice's and Bob's alike -- hits Jira as
+the exact same account. Jira's own audit log can't tell them apart.
+Jira's own permissions can't be different for them. And the very first
+requirement this whole effort was built around -- "let product-team
+users touch Jira, but not GitLab" -- literally cannot be enforced,
+because the server has no concept of *who* is asking.
+
+So there are two genuinely different problems hiding in "authentication"
+here, and this document is organized around keeping them separate,
+because conflating them is the easiest way to design this wrong:
+
+1. **Which credential does a toolset use to talk to Jira (or Confluence,
+   or GitLab, later)?** This is "outbound" -- the toolset calling out to
+   some third-party system. **Part 1 and Part 2** below.
+2. **Who is allowed to talk to `mcp-server` in the first place, and how
+   does it know?** This is "inbound" -- a caller reaching this server.
+   **Part 3** below.
+
+Knowing *who* is calling (problem 2) is what makes it safe to let that
+caller's own credential override the server's default (problem 1). They
+solve different problems, but the second is what makes the first
+trustworthy rather than just self-asserted.
+
+**What this deliberately is not: a credential store.** `mcp-server`
+never saves, encrypts, enrolls, or remembers anyone's credential. It
+accepts one for the duration of one call and uses it, nothing more.
+Storage -- if a deployment wants one-time-per-user enrollment instead of
+re-sending a credential on every call -- is the calling client's job
+(e.g. LibreChat's own per-user encrypted variable storage), not this
+repo's.
+
+---
+
+## Part 1: a toolset's own credential (personal, direct use)
+
+This is unchanged in spirit from how this repo always worked, and it's
+still the *only* thing that matters if you're running a toolset
+yourself, by hand, or through a runtime that reads `SKILL.md` natively
+(Claude Code, Hermes, claude.ai). None of the multi-user machinery in
+Parts 2-3 is involved at all in this path.
+
+### The shape: a `Credential`, not a hardcoded auth scheme
+
+`skills/jira/lib/auth.py` used to hardcode HTTP Basic auth directly:
+`session.auth = (username, password)`. That's now split into two
+independent pieces:
+
+- **`JiraConfig`** -- purely behavioral settings: `base_url`,
+  `timeout_seconds`, `max_retries`, `verify_ssl`,
+  `auto_confirm_writes`, `default_project`, `deployment_type`. No
+  credential material at all.
+- **A `Credential`** -- purely the auth material, returned by
+  `load_credential()`. `JiraClient` never touches `username`/`password`
+  itself; it calls `credential.apply(session)` and the credential
+  decides what that means.
+
+```python
+# skills/_shared/credentials/http.py
+class Credential(Protocol):
+    def apply(self, session: requests.Session) -> None: ...
+
+class BasicCredential:   # HTTP Basic -- username + password
+class BearerCredential:  # Authorization: Bearer <token>
+class NoCredential:      # explicit "no auth needed", not an oversight
+```
+
+`BearerCredential` deliberately covers three different real-world
+things with one type, because the wire format is identical for all of
+them: a Jira Data Center **Personal Access Token**, a plain **API key**,
+or an **OAuth access token**. One code path, whichever of the three a
+deployment actually has.
+
+### Jira's concrete precedence
+
+`skills/jira/lib/auth.py`'s `load_credential()`:
+
+1. **`JIRA_PAT` set** -> `BearerCredential`. Wins if both are set,
+   since minting a PAT is a deliberate choice that should take
+   precedence over a Basic pair that might just be left over.
+2. **`JIRA_USERNAME` + `JIRA_PASSWORD` both set** -> `BasicCredential`.
+3. **Neither fully configured** -> `ConfigurationError`, naming both
+   options in the message so you're not left guessing which var to set.
+
+```mermaid
+flowchart LR
+    START["load_credential()"] --> CHECK_PAT{"JIRA_PAT set?"}
+    CHECK_PAT -->|yes| BEARER["BearerCredential(token)"]
+    CHECK_PAT -->|no| CHECK_BASIC{"JIRA_USERNAME\n+ JIRA_PASSWORD\nboth set?"}
+    CHECK_BASIC -->|yes| BASIC["BasicCredential(user, pass)"]
+    CHECK_BASIC -->|no| ERR["ConfigurationError\n(names both options)"]
+    BEARER --> APPLY["credential.apply(session)"]
+    BASIC --> APPLY
+    APPLY --> REQ["requests.Session, authenticated"]
+```
+
+### Why the shared module is a symlink, not a copy
+
+`skills/_shared/credentials/http.py` holds the `Credential` types.
+`skills/jira/lib/credentials.py` is a **symlink** to it
+(`ln -s ../../_shared/credentials/http.py skills/jira/lib/credentials.py`),
+not a copy -- so a future Confluence or GitLab toolset (both of which
+authenticate a `requests.Session` the same way -- confirmed directly
+from GitLab's own docs that its API accepts `Authorization: Bearer
+<token>`, not just its `PRIVATE-TOKEN` header) can symlink the exact
+same file, and one fix updates every consumer at once.
+
+This survives both ways this repo is consumed, verified against the
+real installer source, not assumed:
+
+- **A direct `git clone`** preserves the symlink natively -- nothing
+  special to do.
+- **`npx skills add --skill jira`** ([`vercel-labs/skills`](https://github.com/vercel-labs/skills))
+  does a real `git clone` of the whole repo into a temp directory (for
+  any repo not on its own fast-path allowlist, which this one isn't),
+  then extracts just the requested skill's directory with
+  `fs.cp(src, dest, { dereference: true })` -- Node's own "follow the
+  symlink and copy the real file" mode. The installer's own source
+  comment explains why: *"If the file is a symlink to elsewhere in a
+  remote skill, it may not resolve correctly once it has been copied to
+  the local location."* This is exactly `skills/jira/lib/credentials.py`'s
+  situation, handled on purpose by the tool's own authors.
+
+**`skills/_shared/` can never itself be installed or discovered as a
+skill.** Both consumers above find skills by walking for `SKILL.md`'s
+presence -- `mcp-server/lib/registry.py`'s `discover_skills()` filters on
+`entry.is_dir() and skill_md.exists()`, and `vercel-labs/skills`'s own
+`discoverSkills()` does the same. A directory with no `SKILL.md` is
+structurally invisible to either, not just conventionally excluded.
+`skills/_shared/README.md` states this explicitly (never add a
+`SKILL.md` there), and `mcp-server/tests/test_registry.py` has two tests
+guarding it: one proving the general mechanism, one checking the real
+`skills/_shared/` directory in this actual repo has no `SKILL.md` today.
+
+### Adding this pattern to a new toolset
+
+1. If the new toolset authenticates an HTTP session the same way (Basic
+   or a bearer token), symlink the existing shared file:
+   `ln -s ../../_shared/credentials/http.py skills/<toolset>/lib/credentials.py`.
+   If it needs a genuinely different shape (see "What's deliberately not
+   built yet" below), that's a new file under `skills/_shared/credentials/`,
+   not a variant crammed into `http.py`.
+2. Write that toolset's own `load_credential(env=None)` in its own
+   `lib/auth.py`, reading whatever env vars make sense for that system
+   (mirroring Jira's `JIRA_PAT`/`JIRA_USERNAME`/`JIRA_PASSWORD` pattern).
+3. Wherever the toolset's client currently does `session.auth = (...)`
+   or sets an `Authorization` header by hand, replace it with
+   `credential.apply(session)`.
+4. Mark the actually-secret vars `sensitive: true` in that toolset's
+   `SKILL.md` frontmatter (see Part 2's redaction section for why).
+5. Nothing in `mcp-server` needs to change for any of this -- Part 2
+   below already works for any toolset whose `required_environment_variables`
+   frontmatter is accurate, generically.
+
+### What's deliberately not built yet
+
+A future **`git`** toolset (operating on repos directly via the `git`
+CLI, not a REST API) needs a genuinely different credential shape --
+SSH keys or a credential helper, not a value you set on a
+`requests.Session`. That's a different enough problem (a private key
+especially should never be handled like a bearer token -- e.g. never
+passed as a header value the way Part 2 does for HTTP credentials) that
+it's intentionally not designed here. When that toolset actually exists,
+it gets its own module under `skills/_shared/credentials/` (e.g.
+`process.py`), built against a real requirement instead of guessed at
+in advance.
+
+---
+
+## Part 2: per-request credentials (`mcp-server`, multi-user)
+
+Everything in Part 1 is what happens when `mcp-server`'s own process
+environment is the only source of truth -- which is still true by
+default, and true always under `stdio`. This part is what changes when
+a deployment opts in to letting different callers use different
+credentials against the same running server.
+
+### The old behavior, and the two problems with it
+
+`mcp-server/lib/execute.py` used to build every subprocess's
+environment as a flat `os.environ.copy()` -- literally, hand the
+toolset's subprocess the server's *entire* environment. Two real
+problems followed from this, found by actually auditing the code rather
+than assumed:
+
+1. **One process, one identity.** There's exactly one `JIRA_USERNAME`
+   in the server's own environment. Every caller uses it. No way to
+   swap in a different credential per request.
+2. **Cross-toolset leakage.** Since the *entire* environment was
+   copied, a Jira subprocess could see `TELEGRAM_*` variables too, and
+   vice versa -- nothing scoped a toolset to only its own declared
+   credentials.
+
+### The fix: scoped, per-call resolution
+
+`mcp-server/lib/credentials.py`'s `resolve_env()` builds a fresh
+environment for every single subprocess call, from exactly two sources:
+
+```mermaid
+flowchart TB
+    CALL["execute_subcommand(manifest, spec, kwargs)"] --> RESOLVE["credentials.resolve_env(manifest, trust_request_credentials)"]
+    RESOLVE --> INFRA["Infra vars present in os.environ\n(PATH, HOME, locale, proxy, CA-bundle vars)"]
+    RESOLVE --> DECLARED["This toolset's OWN declared vars\n(manifest.required_environment_variables)\nsourced from os.environ"]
+    RESOLVE --> TRUST{"trust_request_credentials?"}
+    TRUST -->|"True"| HEADERS["Matching X-Agent-Skills-Env-* headers\noverride the declared vars above"]
+    TRUST -->|"False (default)"| WARN["Headers ignored; one-time\nwarning if any were present"]
+    INFRA --> ENV["Final env dict"]
+    DECLARED --> ENV
+    HEADERS --> ENV
+    ENV --> SPAWN["subprocess.run([python3, script, subcommand, ...], env=ENV)"]
+```
+
+- **Infra vars** (`_INFRA_ENV_VARS` in `credentials.py`): `PATH`, `HOME`,
+  `LANG`/`LANGUAGE`/`LC_ALL`/`LC_CTYPE`, `TMPDIR`/`TMP`/`TEMP`,
+  `PYTHONPATH`/`PYTHONIOENCODING`/`PYTHONUTF8`, and proxy/CA-bundle vars
+  (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` in both cases,
+  `SSL_CERT_FILE`/`SSL_CERT_DIR`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`).
+  None of these are ever toolset-specific credentials, and they're
+  necessary for the subprocess to function at all -- **`PATH` in
+  particular is load-bearing**: confirmed empirically that
+  `subprocess.run` needs `PATH` *in the env dict it's given* to resolve
+  a bare command name like `"python3"` on POSIX, and this repo's own
+  `mcp-server/Dockerfile` installs Python at `/usr/local/bin/python3`
+  (the official `python:3.12-slim` base image's location), not somewhere
+  guaranteed to be covered by any implicit fallback search path.
+- **This toolset's own declared vars only** -- `manifest.required_environment_variables`
+  (already parsed from that toolset's `SKILL.md` frontmatter) is the
+  allowlist. A Jira call never sees `TELEGRAM_*`, full stop -- not
+  filtered out after the fact, never included in the first place.
+
+### Per-request override: the `X-Agent-Skills-Env-*` header
+
+A caller can override one of a toolset's *own* declared vars, for one
+call only, nothing persisted:
+
+```
+X-Agent-Skills-Env-JIRA_USERNAME: alice
+X-Agent-Skills-Env-JIRA_PASSWORD: alices-own-password
+```
+
+Two things keep this from being a way to smuggle in arbitrary
+environment variables:
+
+- **Only vars the toolset itself declares are ever accepted.** A header
+  named `X-Agent-Skills-Env-SOME_RANDOM_VAR` is silently dropped unless
+  `SOME_RANDOM_VAR` is genuinely one of that toolset's own
+  `required_environment_variables` entries.
+- **This is deliberately generic, not LibreChat-specific.** Any HTTP
+  client that can set a header can use it -- there's no assumption
+  baked in about which chat platform is on the other end. (LibreChat
+  happens to have a mechanism, `customUserVars`, that maps naturally
+  onto sending exactly this kind of header per user, but nothing here
+  depends on that specific client.)
+
+**Concrete effect, once trusted (see below):**
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    participant Client as Chat client (e.g. LibreChat)
+    participant Server as mcp-server
+    participant Jira
+
+    Alice->>Client: "what's blocking PAY-123?"
+    Client->>Server: jira_blockers(...)<br/>X-Agent-Skills-Env-JIRA_USERNAME: alice
+    Server->>Jira: GET /rest/api/2/... (as alice)
+    Jira-->>Server: response
+    Server-->>Client: result
+    Client-->>Alice: answer
+
+    Bob->>Client: "log 2h on PAY-456"
+    Client->>Server: jira_worklog(...)<br/>X-Agent-Skills-Env-JIRA_USERNAME: bob
+    Server->>Jira: POST /rest/api/2/... (as bob)
+    Jira-->>Server: response
+    Server-->>Client: result
+    Client-->>Bob: confirmation
+```
+
+Jira's own audit log now says `alice` and `bob`, not one shared service
+account -- and if Alice's Jira account genuinely lacks permission for
+something, Jira's own permission model enforces that correctly, because
+the request really is being made as Alice.
+
+### The trust gate: why headers are ignored by default
+
+**A header is self-asserted.** On an unauthenticated transport, anyone
+who can reach the port could set
+`X-Agent-Skills-Env-JIRA_USERNAME: someone-elses-account` and be
+believed. So these headers are **ignored by default** -- the resolved
+environment falls back to the server's own process env, exactly Part
+1's behavior, and a one-time warning is logged if a header was present
+but ignored (so a misconfiguration is discoverable, not silently
+ineffective).
+
+Honoring them requires **explicitly opting in**:
+`--trust-request-credentials` (or `MCP_TRUST_REQUEST_CREDENTIALS=1`).
+This should only be turned on once something downstream actually
+verifies who's calling -- see Part 3. Turning it on with no auth
+provider configured prints a loud startup warning rather than silently
+accepting a meaningless security posture (verified: this exact warning
+fires in a real process start, worded to name the risk plainly).
+
+### Redaction: a secret must never reach an LLM's context
+
+Everything `execute_subcommand` returns goes straight into a
+`ToolResult`, and therefore into whichever model is driving the chat.
+Two real leak surfaces exist in the error paths:
+
+| Surface | Where | Risk |
+|---|---|---|
+| `argv` | echoed in 4 of `execute.py`'s 5 error shapes | A credential passed as a CLI flag would leak on any failure |
+| `stdout`/`stderr` | echoed in the `nonzero_exit`/`invalid_json_output` shapes | A raw traceback or error message could contain a credential value |
+
+**A var marked `sensitive: true`** in a toolset's `required_environment_variables`
+frontmatter (see `skills/jira/SKILL.md`'s `JIRA_USERNAME`/`JIRA_PASSWORD`/`JIRA_PAT`
+entries) has its *resolved value* stripped from `argv`/`stdout`/`stderr`/`message`
+in every error `execute_subcommand` returns, replaced with
+`***REDACTED***`. This is opt-in per var, not "redact everything" --
+`JIRA_BASE_URL` isn't sensitive, and redacting it would make debugging
+harder for no security benefit.
+
+This is a **convention, not an inference** -- there's no way to guess
+"this var is secret" from its name alone, so a toolset that adds a
+genuinely secret var without marking it `sensitive: true` gets no
+redaction for it. Same tradeoff this repo already accepts for
+`required_for`'s "optional"-prefix convention.
+
+**A real bug was caught here by testing, not by review**: the first
+version of the redaction code checked for `argv`/`stdout`/`stderr` at
+the *top level* of the returned `{"error": {...}}` dict, when those
+keys actually live one level down, inside the nested `"error"` dict --
+so redaction silently did nothing. A test asserting the secret value
+was *actually absent* from the real returned payload (not just "the
+code ran without raising") caught it immediately.
+
+---
+
+## Part 3: inbound auth -- verifying who's calling
+
+Part 2's trust gate is only as meaningful as whatever verifies the
+caller's identity before the gate opens. This part is that verification.
+
+### What this is, and deliberately isn't
+
+`mcp-server/lib/auth.py` builds a [fastmcp](https://gofastmcp.com)
+`AuthProvider`, wired into `FastMCP(auth=...)` in `server.py`. It
+validates a bearer token that some other, already-established flow
+produced (e.g. a chat client's own login against an identity provider,
+forwarded as a header) -- **it does not turn this server into an OAuth
+authorization server**, and it deliberately doesn't do Dynamic Client
+Registration (DCR).
+
+That distinction matters enough to explain: fastmcp ships its own
+`KeycloakAuthProvider`, and it was the obvious first choice -- but it
+assumes an MCP *client* does an interactive browser OAuth flow *against
+Keycloak, through this server*, which needs this server's own public
+`base_url` for OAuth metadata (consent screens, redirect URIs, the
+whole DCR dance). That's the wrong shape for this deployment: this
+server sits on an internal network, reached by one client (a chat app)
+that already holds its own token from its own separate login. What's
+actually needed is simpler -- validate a token, don't issue one -- so
+`lib/auth.py` uses fastmcp's `JWTVerifier` directly, pointed at
+Keycloak's own JWKS endpoint, replicating the same derivation
+`KeycloakAuthProvider` does internally without pulling in the DCR
+machinery this use case doesn't need.
+
+### Configuration -- opt-in, on its own env vars
+
+```bash
+MCP_AUTH_KEYCLOAK_REALM_URL=https://keycloak.example.com/realms/myrealm
+MCP_AUTH_KEYCLOAK_AUDIENCE=my-mcp-server   # optional but recommended in production
+```
+
+Providing `MCP_AUTH_KEYCLOAK_REALM_URL` **is** the opt-in -- there's no
+separate `--auth-provider=keycloak` flag to also set, matching the same
+"presence of the var is the whole decision" pattern every toolset's own
+credentials already use. Absent it, `build_auth_provider()` returns
+`None` and `FastMCP(auth=None)` is exactly today's (no-auth) behavior.
+
+`lib/auth.py`'s `_PROVIDER_FACTORIES` tuple is where a second provider
+(a different OIDC issuer, a static token for local testing via
+fastmcp's own `StaticTokenVerifier`, ...) would be added -- checked in
+order, first one whose own env vars are present wins.
+
+### Verified against a real running server, not just construction
+
+```bash
+# No auth configured -- default, unaffected:
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:PORT/mcp ...
+# => 200
+
+# MCP_AUTH_KEYCLOAK_REALM_URL set, no token presented:
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:PORT/mcp ...
+# => 401
+```
+
+Both of these were run against real server processes while building
+this, not inferred from reading fastmcp's source.
+
+---
+
+## Part 4: security properties (what's actually guaranteed)
+
+A concrete checklist, since "is this actually safe" deserves a direct
+answer rather than trusting the prose above.
+
+**Guaranteed:**
+
+- Personal/direct use (no `mcp-server` involved) is completely
+  unaffected by anything in Parts 2-3 -- same env vars, same behavior,
+  always.
+- Under `stdio`, per-request headers are structurally impossible
+  (`get_http_headers()` returns `{}` with no active HTTP request), so
+  Parts 2-3 are entirely moot regardless of any flag.
+- A per-request credential header is only ever honored when
+  `--trust-request-credentials` is explicitly set.
+- A toolset's subprocess never receives another toolset's declared
+  credentials, regardless of trust settings.
+- A var marked `sensitive: true` never appears in `argv`/`stdout`/`stderr`
+  of any error this server returns.
+- Setting `--trust-request-credentials` with no auth provider configured
+  produces a loud, explicit startup warning, not silent acceptance.
+- With a real auth provider configured, an unauthenticated request is
+  genuinely rejected (`401`), verified against a live server.
+
+**Not guaranteed -- explicitly out of scope, know this before relying on it:**
+
+- **No credential storage of any kind.** Nothing here remembers a
+  credential between calls. A client wanting "enter your PAT once" UX
+  has to implement that storage itself (LibreChat's `customUserVars`
+  does).
+- **No OAuth proxying to third-party services** (e.g. Figma's own MCP
+  server). A chat client should connect to those directly and let them
+  handle their own OAuth -- this repo's inbound auth (Part 3) is about
+  *this* server's callers, not about brokering tokens for other
+  services.
+- **Network isolation is still required, not optional.** Auth is
+  defense in depth on top of "don't expose this port publicly," not a
+  substitute for it -- `mcp-server/README.md` says this explicitly.
+- **`--include-internal` skills (e.g. `telegram`) are out of scope for
+  all of this.** `telegram`'s credential is an on-disk Telethon session
+  that *is* one specific person's account -- inherently single-identity,
+  and already excluded from MCP by default for a different, unrelated
+  reason (its write-actions' `/dev/tty` confirm gate can't work in a
+  headless server at all).
+- **A CLI flag like `--confirm` is a separate concern entirely** --
+  covered by `ARCHITECTURE.md`'s "Security model", not this document.
+  Confirm-gating decides *whether* a write happens; this document is
+  about *who* it happens as. Both apply independently to the same
+  action.
+
+---
+
+## Part 5: environment variable and header reference
+
+| Name | Where it's read | Purpose |
+|---|---|---|
+| `JIRA_BASE_URL` | `skills/jira/lib/auth.py` | Jira instance root URL. Required. Not sensitive. |
+| `JIRA_USERNAME` | `skills/jira/lib/auth.py` | Basic-auth username. Sensitive. Required with `JIRA_PASSWORD` unless `JIRA_PAT` is set. |
+| `JIRA_PASSWORD` | `skills/jira/lib/auth.py` | Basic-auth password. Sensitive. Required with `JIRA_USERNAME` unless `JIRA_PAT` is set. |
+| `JIRA_PAT` | `skills/jira/lib/auth.py` | Bearer token (PAT/API key/OAuth token). Sensitive. Alternative to `JIRA_USERNAME`/`JIRA_PASSWORD`; wins if both are set. |
+| `X-Agent-Skills-Env-<VAR>` (HTTP header) | `mcp-server/lib/credentials.py` | Per-request override of one of a toolset's own declared vars. Only honored when trusted (see below); silently limited to vars that toolset actually declares. |
+| `MCP_TRUST_REQUEST_CREDENTIALS` | `mcp-server/lib/credentials.py` (via `server.py`'s `--trust-request-credentials`) | `1` to honor the header above. Default: unset (headers ignored). |
+| `MCP_AUTH_KEYCLOAK_REALM_URL` | `mcp-server/lib/auth.py` | Keycloak realm URL. Presence is the entire opt-in for inbound JWT auth. |
+| `MCP_AUTH_KEYCLOAK_AUDIENCE` | `mcp-server/lib/auth.py` | Optional expected `aud` claim. Recommended once this is more than local testing. |
+| `AGENT_SKILLS_REPO_ROOT` | `mcp-server/server.py` | Unrelated to auth, but frequently confused with it -- this is *where the repo is*, not a credential. Defaults to the parent of `mcp-server/`. |
+
+---
+
+## Part 6: launching each deployment model
+
+Four shapes, in increasing order of how many people share one running
+server. Pick the one matching your situation; each is genuinely
+independent, and nothing about "correct setup" here requires the others.
+
+### 1. Direct/personal use -- no `mcp-server` at all
+
+For Claude Code, Hermes, or claude.ai reading `SKILL.md` natively.
+
+```bash
+# Once, per checkout:
+cd skills/jira
+pip install -r requirements.txt
+
+# Every session, set whichever mode you're using:
+export JIRA_BASE_URL=https://jira.mycompany.com
+export JIRA_USERNAME=you@example.com
+export JIRA_PASSWORD=...
+# -- or, instead of the two lines above --
+export JIRA_PAT=...
+
+python3 scripts/jira_tool.py now   # sanity check -- no Jira call, just confirms the CLI runs
+python3 scripts/jira_tool.py my_work
+```
+
+Nothing in this document past Part 1 is relevant here at all -- Parts
+2-3 don't exist in this deployment shape.
+
+### 2. MCP over stdio -- a client spawns the server itself
+
+For Claude Desktop, or any MCP client that runs the server as a
+subprocess rather than connecting to a URL.
+
+```json
+{
+  "mcpServers": {
+    "agent-skills": {
+      "command": "python3",
+      "args": ["/path/to/agent-skills/mcp-server/server.py"],
+      "env": {
+        "JIRA_BASE_URL": "https://jira.mycompany.com",
+        "JIRA_USERNAME": "you@example.com",
+        "JIRA_PASSWORD": "..."
+      }
+    }
+  }
+}
+```
+
+Still single-identity, same as direct use -- one client, one person,
+one set of credentials in the client's own config. `--trust-request-credentials`
+and `MCP_AUTH_KEYCLOAK_REALM_URL` are meaningless here: there's no
+network request to attach a header to or authenticate.
+
+### 3. MCP over HTTP, single-tenant -- Dify or a similar single-user client
+
+```bash
+python3 server.py --transport http --host 0.0.0.0 --port 8321
+```
+
+with `JIRA_BASE_URL`/`JIRA_USERNAME`/`JIRA_PASSWORD` (or `JIRA_PAT`) set
+in the server's own process environment (`-e`/`--env-file` if this runs
+in a container -- see `mcp-server/README.md`'s "Running in a
+container"). This is Part 1's behavior served over a network instead of
+a local pipe -- still one identity for every caller, because there's
+only one caller (or every caller is meant to act as the same account).
+**Do not** set `--trust-request-credentials` in this shape; there's
+nothing to gain from it and it adds risk for no benefit.
+
+### 4. MCP over HTTP, multi-user -- a chat client serving many people
+
+This is Parts 2-3 together. Two sub-cases, and the difference between
+them matters:
+
+**4a. Development/testing only -- trust without verified identity.**
+
+```bash
+python3 server.py --transport http --host 0.0.0.0 --port 8321 \
+  --trust-request-credentials
+```
+
+This *works* -- a client sending `X-Agent-Skills-Env-JIRA_USERNAME`
+headers gets per-request credential switching -- but anyone who can
+reach the port can claim to be anyone. **Never run this shape reachable
+by anything other than a fully trusted network you control end to end.**
+The startup warning that fires here exists specifically to stop this
+from being a deployment's actual production configuration by accident.
+
+**4b. Production -- trust backed by real verification.**
+
+```bash
+python3 server.py --transport http --host 0.0.0.0 --port 8321 \
+  --trust-request-credentials
+```
+
+with, additionally, in the server's environment:
+
+```bash
+MCP_AUTH_KEYCLOAK_REALM_URL=https://keycloak.example.com/realms/myrealm
+MCP_AUTH_KEYCLOAK_AUDIENCE=my-mcp-server
+```
+
+Now an unauthenticated request is genuinely rejected (`401`), and the
+per-request headers this server honors are only reachable by a caller
+that already proved who they are. This is the shape this whole feature
+was built for: a chat client where each logged-in user's own Jira
+action lands under their own Jira identity, not a shared service
+account.
+
+**Getting the client side right is out of this repo's scope but worth
+naming:** something has to (a) authenticate to this server with a real
+token Keycloak issued, and (b) send each user's own Jira credential (a
+PAT they've entered once, since Jira Data Center has no per-user OAuth
+flow to lean on) as the `X-Agent-Skills-Env-JIRA_*` header on their
+calls. A client like LibreChat's `customUserVars` feature is built to
+do exactly (b); wiring (a) depends on whatever that specific client's
+own MCP-authentication support looks like.
+
+### Troubleshooting
+
+- **Startup prints the `--trust-request-credentials` warning** -- you
+  set the flag without configuring `MCP_AUTH_KEYCLOAK_REALM_URL` (or
+  another provider). Either configure one, or confirm you genuinely
+  mean case 4a above and network isolation is doing the real work.
+- **A `jira_*` call returns `missing_environment_variables` unexpectedly**
+  -- check that the credential you expect is actually present in the
+  *resolved* environment, not just somewhere in the server's own
+  environment -- if you're relying on a header override, confirm
+  `--trust-request-credentials` is actually set, since an untrusted
+  header is silently ignored (by design) rather than erroring loudly.
+- **Every caller still hits Jira as the same account despite headers
+  being sent** -- almost always the trust flag isn't actually set;
+  check the server's own startup log/warnings first.
+- **A request gets `401` unexpectedly** -- confirm the token's issuer
+  matches `MCP_AUTH_KEYCLOAK_REALM_URL` exactly (including trailing
+  slash handling -- this server strips a trailing slash from the realm
+  URL itself before deriving the JWKS endpoint and issuer, so the
+  token's own `iss` claim must match the realm URL *without* a trailing
+  slash).

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -132,6 +132,74 @@ agent can never self-approve a send" guarantee `skills/telegram/`
 is built around. Reads, `mark_read`, `download_media`, `whoami`,
 `allowed_chats`, and `logout` work normally either way.
 
+### Multi-user credentials and inbound auth
+
+Everything above describes a single identity: whatever `JIRA_*`/`TELEGRAM_*`
+vars are set in this server's own process environment is what every caller
+uses, always. That's exactly right for personal/direct use (one person,
+one process), but it means a multi-user client sharing one running
+`mcp-server` -- LibreChat, say -- would have every user's Jira actions land
+under the same account, with no way to tell them apart.
+
+Two independent, both-opt-in pieces close that gap without changing
+anything for personal use.
+
+**Per-request credential override.** A caller can supply
+`X-Agent-Skills-Env-<VAR>` as an HTTP header (e.g.
+`X-Agent-Skills-Env-JIRA_PASSWORD`) to override one of a toolset's own
+declared env vars for that single call. Two things keep this safe:
+
+- Only vars the toolset itself declares in its `required_environment_variables`
+  frontmatter are ever accepted this way -- a header can't inject an
+  arbitrary env var name into the subprocess, and a toolset's subprocess
+  never receives another toolset's vars either (Jira never sees
+  `TELEGRAM_*`, and vice versa).
+- These headers are **ignored by default**. A caller-supplied header is
+  self-asserted -- on an unauthenticated transport, anyone who can reach
+  the port could claim to be anyone. Pass `--trust-request-credentials`
+  (or set `MCP_TRUST_REQUEST_CREDENTIALS=1`) to start honoring them, and
+  do that only once something downstream actually verifies who's calling
+  -- see the next part. Setting it without a configured provider prints a
+  loud warning at startup rather than silently accepting the
+  misconfiguration.
+
+**Inbound auth.** `--transport http`/`sse`/`streamable-http` can require
+callers to authenticate, using [fastmcp](https://gofastmcp.com)'s own
+`AuthProvider` support (`lib/auth.py`). Currently available:
+
+- **Keycloak / any OIDC provider issuing JWTs** -- set
+  `MCP_AUTH_KEYCLOAK_REALM_URL` (e.g.
+  `https://keycloak.example.com/realms/myrealm`) and this server validates
+  bearer tokens against that realm's own JWKS endpoint. Optionally set
+  `MCP_AUTH_KEYCLOAK_AUDIENCE` to also check the token's `aud` claim
+  (recommended once this is more than local testing). Providing the realm
+  URL *is* the opt-in -- there's no separate flag to also flip.
+
+  This uses `fastmcp`'s `JWTVerifier` directly, not its `KeycloakAuthProvider`
+  -- that one assumes an MCP client does an interactive browser OAuth flow
+  against Keycloak *through* this server (Dynamic Client Registration),
+  which needs this server's own public URL for OAuth metadata. That's the
+  wrong shape for an internal-network server reached by one client that
+  already holds its own token (e.g. from its own separate login flow) and
+  just needs it validated.
+- No provider configured (the default) -- `stdio` is unaffected either
+  way (no network boundary to protect); HTTP/SSE/streamable-HTTP accept
+  any request, same as before this feature existed.
+
+With both pieces on, `mcp-server` can hand a Jira request Alice's
+credential and a different request Bob's, instead of every caller hitting
+Jira as whatever this server's own environment says -- without either
+toolset's own code knowing or caring where its credential came from.
+
+**A var marked `sensitive: true` in a toolset's `required_environment_variables`
+frontmatter never appears in error output.** `argv`/`stdout`/`stderr` in
+any error this server returns are checked against every sensitive var's
+resolved value and redacted before the result reaches a caller (and
+therefore before it reaches an LLM's context) -- see `skills/jira/SKILL.md`'s
+`JIRA_USERNAME`/`JIRA_PASSWORD`/`JIRA_PAT` entries for the convention. A
+non-sensitive var (`JIRA_BASE_URL`, say) is left untouched so debugging
+output isn't needlessly harder to read.
+
 ### Running in a container
 
 `Dockerfile` (in this directory) builds an image that runs the server over
@@ -158,10 +226,12 @@ above). Credentials still come from environment variables only, exactly as
 running the server directly -- pass them with `-e` / `--env-file`, or via
 whatever your orchestrator's secret mechanism is.
 
-The image binds `0.0.0.0:8321` with no authentication of any kind -- the MCP
-HTTP transport has none built in. Never publish this container's port to a
-public network; put it on a private/internal network reachable only by the
-MCP client that needs it (Dify, LibreChat, ...).
+The image binds `0.0.0.0:8321` with no authentication unless you configure
+one -- see "Multi-user credentials and inbound auth" below. Never publish
+this container's port to a public network regardless; put it on a
+private/internal network reachable only by the MCP client that needs it
+(Dify, LibreChat, ...) even once auth is configured -- that's defense in
+depth, not a substitute for network isolation.
 
 ## Tool naming and shape
 
@@ -211,6 +281,12 @@ Fixed tools that exist regardless of which toolsets are installed:
   starting with the literal word "optional" for a genuinely optional
   var, anything else meaning required. A future `SKILL.md` that doesn't
   follow that convention could be misclassified.
+- **`sensitive: true` (redaction) is opt-in per var, trusted the same way.**
+  A toolset that declares a genuinely secret var without marking it
+  `sensitive: true` gets no redaction for that var's value in error output
+  -- there's no way to infer sensitivity from a var's name alone, so this
+  is deliberately convention over inference, same tradeoff as
+  `required_for` above.
 - **Tool-schema generation relies on `argparse`'s private attributes**
   (`_subparsers`, `_choices_actions`, `_StoreTrueAction`, `_AppendAction`,
   ...). Stable across Python's stdlib for well over a decade, but not a

--- a/mcp-server/lib/auth.py
+++ b/mcp-server/lib/auth.py
@@ -1,0 +1,72 @@
+"""Builds this server's inbound `AuthProvider`, if one is configured.
+
+Verifying *who* is calling is what lets `lib/credentials.py` decide
+whether to trust a per-request credential header instead of always
+falling back to this server's own process environment -- see that
+module's own docstring for the full picture. This module only builds
+the provider fastmcp's `FastMCP(auth=...)` consumes; it doesn't touch
+credential resolution itself.
+
+Deliberately narrow: every provider here validates a bearer token that
+some other already-established flow produced (e.g. a chat client's own
+Keycloak login, forwarded as a header) -- none of them make this server
+into an OAuth authorization server itself. fastmcp's own
+`KeycloakAuthProvider` assumes the opposite shape (Dynamic Client
+Registration -- an MCP client doing an interactive browser OAuth flow
+against Keycloak *through* this server, which needs this server's own
+public `base_url` for OAuth metadata). That's the wrong tool here: this
+server sits on an internal network, reached by one client that already
+holds its own token, not by arbitrary MCP clients registering
+themselves. `JWTVerifier` configured directly against Keycloak's JWKS
+endpoint covers the actual need with less machinery.
+
+Every provider is opt-in, gated purely on its own env vars being
+present -- there is no separate `--auth-provider=keycloak` flag to also
+set. Absent those vars, `build_auth_provider()` returns None and
+`FastMCP(auth=None)` is exactly today's behavior.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastmcp.server.auth import AuthProvider
+
+
+def _keycloak_provider() -> AuthProvider | None:
+    """Built only when MCP_AUTH_KEYCLOAK_REALM_URL is set -- providing
+    that var is the entire opt-in.
+
+    MCP_AUTH_KEYCLOAK_REALM_URL: the realm's own URL, e.g.
+        https://keycloak.example.com/realms/myrealm
+    MCP_AUTH_KEYCLOAK_AUDIENCE: optional -- expected `aud` claim.
+        Recommended once this is used for anything beyond local testing,
+        same as fastmcp's own JWTVerifier docs recommend.
+    """
+    realm_url = os.environ.get("MCP_AUTH_KEYCLOAK_REALM_URL")
+    if not realm_url:
+        return None
+
+    from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+    realm_url = realm_url.rstrip("/")
+    return JWTVerifier(
+        jwks_uri=f"{realm_url}/protocol/openid-connect/certs",
+        issuer=realm_url,
+        algorithm="RS256",
+        audience=os.environ.get("MCP_AUTH_KEYCLOAK_AUDIENCE") or None,
+    )
+
+
+#: Checked in order; the first provider whose own env vars are present
+#: wins. Add a new provider function above and list it here -- nothing
+#: else in this repo needs to change to support it.
+_PROVIDER_FACTORIES = (_keycloak_provider,)
+
+
+def build_auth_provider() -> AuthProvider | None:
+    for factory in _PROVIDER_FACTORIES:
+        provider = factory()
+        if provider is not None:
+            return provider
+    return None

--- a/mcp-server/lib/credentials.py
+++ b/mcp-server/lib/credentials.py
@@ -1,0 +1,189 @@
+"""Per-call environment resolution for a toolset's subprocess.
+
+`execute.py` used to build every subprocess's environment as a flat
+`os.environ.copy()` -- one process, one identity, and every toolset
+inheriting every *other* toolset's credentials along the way. This
+module replaces that with two things:
+
+1. **Scoping.** A subprocess only ever sees the infra vars every
+   subprocess needs to run at all (`_INFRA_ENV_VARS` below), plus the
+   *one* toolset's own declared `required_environment_variables` --
+   never another toolset's. `manifest.required_environment_variables`
+   (already parsed from that toolset's own `SKILL.md` frontmatter) is
+   the allowlist.
+2. **Per-request override.** A caller-supplied HTTP header can override
+   one of those declared vars for a single call -- e.g. so `mcp-server`
+   can hand a Jira request Alice's credential and a different request
+   Bob's, instead of both hitting Jira as whatever the server process's
+   own environment says. This is honored only when `trusted=True` --
+   self-asserted headers on an unauthenticated transport are trivially
+   spoofable, so an unconfigured deployment must ignore them and fall
+   back to the process env, not silently trust whoever can reach the
+   port.
+
+`get_http_headers()` (fastmcp) is documented to never raise and to
+return `{}` when there's no active HTTP request -- so this resolves
+identically under stdio (personal/direct use) and HTTP, with no
+transport branching: under stdio there's simply never anything to
+override.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .registry import SkillManifest
+
+logger = logging.getLogger("mcp_server.credentials")
+
+#: Env vars every subprocess needs regardless of which toolset it is --
+#: none of these are ever toolset-specific credentials. PATH in
+#: particular is load-bearing: `subprocess.run` given a bare command
+#: name (e.g. "python3", not an absolute path) needs PATH *in the env
+#: dict it's given* to resolve it on POSIX -- omitting it isn't merely
+#: "less complete," it can leave the interpreter unable to spawn at all
+#: depending on where python3 actually lives (e.g. /usr/local/bin/python3
+#: in this repo's own Dockerfile's python:3.12-slim base, which isn't
+#: guaranteed to be covered by any implicit fallback search path).
+_INFRA_ENV_VARS = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "LANG",
+        "LANGUAGE",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "PYTHONPATH",
+        "PYTHONIOENCODING",
+        "PYTHONUTF8",
+        # requests/urllib3 read these directly for proxying and custom CA
+        # bundles -- relevant here specifically because this repo's own
+        # Jira docs anticipate self-signed certs on internal instances.
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+    }
+)
+
+#: Header name prefix for a per-request env var override, e.g.
+#: `X-Agent-Skills-Env-JIRA_USERNAME`. Deliberately generic -- not tied
+#: to LibreChat or any other specific client; any HTTP client that can
+#: set a header can use this.
+_HEADER_PREFIX = "x-agent-skills-env-"  # get_http_headers() lowercases names
+
+_warned_untrusted_headers_seen = False
+
+
+#: Whether this server instance trusts per-request credential headers,
+#: set once at startup (see `configure()`) from server.py's own
+#: --trust-request-credentials flag / MCP_TRUST_REQUEST_CREDENTIALS env
+#: var. Mirrors how server.py already resolves --include-internal once
+#: at startup and uses it throughout -- a single process, configured
+#: once, not something threaded as an explicit parameter through every
+#: layer between server.py and here. Defaults False: today's behavior
+#: (headers ignored, process env used) unless a deployment opts in.
+_trust_request_credentials = False
+
+
+def configure(*, trust_request_credentials: bool) -> None:
+    """Called once by server.py at startup. Not meant to be called
+    per-request or mid-run -- this is process-lifetime configuration,
+    the same as which transport or which toolsets are active.
+    """
+    global _trust_request_credentials
+    _trust_request_credentials = trust_request_credentials
+
+
+def is_trusted() -> bool:
+    return _trust_request_credentials
+
+
+def resolve_trust_request_credentials(cli_flag: bool) -> bool:
+    """--trust-request-credentials (explicit at launch) wins; otherwise
+    fall back to MCP_TRUST_REQUEST_CREDENTIALS=1 -- same
+    flag-or-env-var-fallback shape as
+    `lib.registry.resolve_include_internal`, so the two config
+    mechanisms already in this server agree instead of diverging.
+    """
+    if cli_flag:
+        return True
+    return os.environ.get("MCP_TRUST_REQUEST_CREDENTIALS") == "1"
+
+
+def _declared_var_names(manifest: "SkillManifest") -> set[str]:
+    return {v["name"] for v in manifest.required_environment_variables}
+
+
+def _get_http_headers() -> dict[str, str]:
+    """Isolated so tests can monkeypatch this one call instead of the
+    whole fastmcp import chain, and so a missing/incompatible fastmcp
+    import can't take down every toolset call -- see the except below.
+    """
+    try:
+        from fastmcp.server.dependencies import get_http_headers
+    except ImportError:  # pragma: no cover -- fastmcp is a hard dependency in practice
+        return {}
+    return get_http_headers()
+
+
+def _header_overrides(declared: set[str]) -> dict[str, str]:
+    """Per-request header values, filtered to only vars this toolset
+    actually declares -- a caller can never inject an arbitrary env var
+    name into the subprocess by naming it in a header.
+    """
+    overrides: dict[str, str] = {}
+    for header_name, value in _get_http_headers().items():
+        if not header_name.startswith(_HEADER_PREFIX):
+            continue
+        var_name = header_name[len(_HEADER_PREFIX) :].upper().replace("-", "_")
+        if var_name in declared:
+            overrides[var_name] = value
+    return overrides
+
+
+def resolve_env(manifest: "SkillManifest", *, trust_request_credentials: bool) -> dict[str, str]:
+    """Build the environment for one toolset subprocess call.
+
+    Scoped to infra vars plus exactly this toolset's own declared vars
+    -- never another toolset's. Declared vars are sourced from the
+    server's own process environment by default; when
+    `trust_request_credentials` is True, a matching per-request header
+    overrides that for this one call only (nothing is persisted).
+    """
+    declared = _declared_var_names(manifest)
+
+    env: dict[str, str] = {name: os.environ[name] for name in _INFRA_ENV_VARS if name in os.environ}
+    env.update({name: os.environ[name] for name in declared if name in os.environ})
+
+    overrides = _header_overrides(declared)
+    if trust_request_credentials:
+        env.update(overrides)
+    elif overrides:
+        global _warned_untrusted_headers_seen
+        if not _warned_untrusted_headers_seen:
+            logger.warning(
+                "Received %d credential header(s) (%s) for toolset %r but "
+                "trust_request_credentials is not enabled -- ignoring them "
+                "and using this server's own environment instead. Pass "
+                "--trust-request-credentials (only once an AuthProvider "
+                "verifies callers) to honor per-request credentials.",
+                len(overrides),
+                ", ".join(sorted(overrides)),
+                manifest.toolset,
+            )
+            _warned_untrusted_headers_seen = True
+
+    return env

--- a/mcp-server/lib/execute.py
+++ b/mcp-server/lib/execute.py
@@ -8,6 +8,15 @@ timeout, missing env vars) into the same `{"error": {...}}` shape those
 scripts already use for a handled failure, so a caller never has to
 special-case "the wrapper failed" vs. "the tool itself reported an
 error".
+
+The subprocess's environment is resolved per call, not just inherited
+wholesale from this server's own process -- see `credentials.py`. That
+resolution is scoped to exactly the toolset's own declared
+`required_environment_variables`, so credentials are never accidentally
+handed to a subprocess for a *different* toolset; and any secret value
+that resolution injected is redacted from every error payload below,
+since everything this function returns goes straight into an LLM's
+context via the calling tool's `ToolResult`.
 """
 
 from __future__ import annotations
@@ -17,6 +26,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING, Any
 
+from . import credentials
 from .introspect import SubcommandSpec
 
 if TYPE_CHECKING:
@@ -25,21 +35,63 @@ if TYPE_CHECKING:
 DEFAULT_TIMEOUT_SECONDS = 60
 
 
-def _missing_required_env_vars(manifest: "SkillManifest") -> list[str]:
+def _missing_required_env_vars(manifest: "SkillManifest", env: dict[str, str]) -> list[str]:
     """`required_for` is free prose, not an enum -- every SKILL.md in this
     repo currently writes it starting with the literal word "optional"
     for a genuinely optional var, and something else otherwise. This
     trusts that convention; it's a heuristic over prose, not a real
     schema, and could misclassify a future SKILL.md that doesn't follow
     it.
+
+    Checks `env` (the already-resolved per-call environment -- see
+    `credentials.resolve_env`), not the server process's own
+    `os.environ` directly, so a per-request credential header that
+    supplies a var this server's own environment doesn't have is
+    correctly recognized as present.
     """
     missing = []
     for var in manifest.required_environment_variables:
         required_for = str(var.get("required_for", "")).strip().lower()
         is_optional = required_for.startswith("optional")
-        if not is_optional and not os.environ.get(var["name"]):
+        if not is_optional and not env.get(var["name"]):
             missing.append(var["name"])
     return missing
+
+
+def _sensitive_values(manifest: "SkillManifest", env: dict[str, str]) -> list[str]:
+    """Every resolved value for a var this toolset's own SKILL.md marks
+    `sensitive: true` -- these are what `_redact` strips from anything
+    returned to the caller. Deliberately opt-in per var (not "redact
+    every declared var's value") so a non-secret value like
+    JIRA_BASE_URL isn't stripped out of error messages for no reason.
+    """
+    return [
+        env[var["name"]]
+        for var in manifest.required_environment_variables
+        if var.get("sensitive") and env.get(var["name"])
+    ]
+
+
+def _redact(value: str, secrets: list[str]) -> str:
+    for secret in secrets:
+        value = value.replace(secret, "***REDACTED***")
+    return value
+
+
+def _redact_error(payload: dict[str, Any], secrets: list[str]) -> dict[str, Any]:
+    """`payload` is always the `{"error": {...}}` shape every error branch
+    below returns -- the fields worth redacting (argv/stdout/stderr/
+    message) live inside that nested "error" dict, not at the top level.
+    """
+    if not secrets:
+        return payload
+    error = dict(payload["error"])
+    if "argv" in error:
+        error["argv"] = [_redact(a, secrets) for a in error["argv"]]
+    for key in ("stdout", "stderr", "message"):
+        if key in error and isinstance(error[key], str):
+            error[key] = _redact(error[key], secrets)
+    return {"error": error}
 
 
 def _build_argv(python: str, script: str, subcommand: str, spec: SubcommandSpec, kwargs: dict[str, Any]) -> list[str]:
@@ -67,8 +119,21 @@ def execute_subcommand(
     kwargs: dict[str, Any],
     *,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    missing = _missing_required_env_vars(manifest)
+    """`env`, when omitted (the normal case -- every real caller leaves
+    this as None), is resolved fresh per call via `credentials.resolve_env`,
+    honoring a per-request credential header only if this server was
+    started with trust in that established (see `credentials.configure`).
+    The explicit parameter exists mainly so tests can inject a specific
+    environment without needing to mock the resolution machinery itself.
+    """
+    if env is None:
+        env = credentials.resolve_env(manifest, trust_request_credentials=credentials.is_trusted())
+
+    secrets = _sensitive_values(manifest, env)
+
+    missing = _missing_required_env_vars(manifest, env)
     if missing:
         return {"error": {"type": "missing_environment_variables", "missing": missing}}
 
@@ -82,39 +147,48 @@ def execute_subcommand(
             timeout=timeout_seconds,
             shell=False,
             cwd=str(manifest.script_path.parent.parent),
-            env=os.environ.copy(),
+            env=env,
         )
     except subprocess.TimeoutExpired:
-        return {
-            "error": {
-                "type": "timeout",
-                "message": f"{manifest.toolset} {spec.name} exceeded {timeout_seconds}s.",
-                "argv": argv,
-            }
-        }
+        return _redact_error(
+            {
+                "error": {
+                    "type": "timeout",
+                    "message": f"{manifest.toolset} {spec.name} exceeded {timeout_seconds}s.",
+                    "argv": argv,
+                }
+            },
+            secrets,
+        )
     except OSError as exc:
-        return {"error": {"type": "spawn_failed", "message": str(exc), "argv": argv}}
+        return _redact_error({"error": {"type": "spawn_failed", "message": str(exc), "argv": argv}}, secrets)
 
     if proc.returncode != 0:
-        return {
-            "error": {
-                "type": "nonzero_exit",
-                "exit_code": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-                "argv": argv,
-            }
-        }
+        return _redact_error(
+            {
+                "error": {
+                    "type": "nonzero_exit",
+                    "exit_code": proc.returncode,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                    "argv": argv,
+                }
+            },
+            secrets,
+        )
 
     try:
         return json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return {
-            "error": {
-                "type": "invalid_json_output",
-                "message": "Subcommand exited 0 but stdout was not a single JSON document.",
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-                "argv": argv,
-            }
-        }
+        return _redact_error(
+            {
+                "error": {
+                    "type": "invalid_json_output",
+                    "message": "Subcommand exited 0 but stdout was not a single JSON document.",
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                    "argv": argv,
+                }
+            },
+            secrets,
+        )

--- a/mcp-server/lib/mcp_tools.py
+++ b/mcp-server/lib/mcp_tools.py
@@ -15,6 +15,7 @@ end-to-end against the real `fastmcp` package before writing this.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Callable
 
 from fastmcp.tools.base import Tool, ToolResult
@@ -36,7 +37,15 @@ class GeneratedTool(Tool):
     handler: Callable[[dict[str, Any]], dict[str, Any]] = Field(exclude=True)
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
-        return ToolResult(content=self.handler(arguments))
+        # self.handler ends in subprocess.run(..., timeout=60) --
+        # genuinely blocking, not just synchronous-looking. Calling it
+        # inline here would block the whole event loop for up to 60s
+        # despite this method being `async def`: nothing yields control
+        # until that call returns, so one in-flight call would stall
+        # every other concurrent caller's tool calls on this same
+        # server. asyncio.to_thread offloads it to fastmcp's thread
+        # pool so other requests keep being served while this one runs.
+        return ToolResult(content=await asyncio.to_thread(self.handler, arguments))
 
 
 def _json_schema_property(param: ParamSpec) -> dict[str, Any]:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -30,7 +30,9 @@ from fastmcp import FastMCP
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from lib import credentials  # noqa: E402
 from lib.adapter_note import adapter_note  # noqa: E402
+from lib.auth import build_auth_provider  # noqa: E402
 from lib.doc_gen import build_doc_gen_tool  # noqa: E402
 from lib.introspect import IntrospectionError  # noqa: E402
 from lib.mcp_tools import register_toolset_tools  # noqa: E402
@@ -50,6 +52,12 @@ def build_app(*, include_internal: bool) -> FastMCP:
 
     app = FastMCP(
         name="agent-skills",
+        # None (the default) unless a provider's own env vars are set --
+        # see lib/auth.py. Verifying who's calling is what lets
+        # lib/credentials.py decide whether to trust a per-request
+        # credential header instead of always falling back to this
+        # server's own process env.
+        auth=build_auth_provider(),
         instructions=(
             "Exposes this repo's skills/ toolsets as typed MCP tools "
             "(one tool per CLI subcommand, named <toolset>_<subcommand>) "
@@ -133,6 +141,22 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--trust-request-credentials",
+        action="store_true",
+        help=(
+            "Honor a per-request credential header (X-Agent-Skills-Env-<VAR>) "
+            "instead of always using this server's own environment -- lets a "
+            "multi-user client hand a toolset a different caller's credential "
+            "per call. Falls back to MCP_TRUST_REQUEST_CREDENTIALS=1 if this "
+            "flag isn't passed. Only meaningful with --transport http/sse/"
+            "streamable-http; a self-asserted header on an unauthenticated "
+            "transport is trivially spoofable, so this should only be set "
+            "once an --auth-* provider (see lib/auth.py's env vars) actually "
+            "verifies who's calling -- setting it without one is flagged at "
+            "startup, not silently accepted."
+        ),
+    )
+    parser.add_argument(
         "--transport",
         choices=["stdio", "http", "sse", "streamable-http"],
         default="stdio",
@@ -175,6 +199,21 @@ def main() -> None:
     global app
     if args.include_internal:
         app = build_app(include_internal=True)
+
+    trust_request_credentials = credentials.resolve_trust_request_credentials(
+        args.trust_request_credentials
+    )
+    if trust_request_credentials and app.auth is None:
+        print(
+            "agent-skills mcp-server: --trust-request-credentials is set but no "
+            "auth provider is configured (see lib/auth.py's env vars) -- a "
+            "caller's self-asserted credential header will be honored with "
+            "nothing verifying who's actually calling. Configure a provider "
+            "first unless this server is reachable only by a caller you "
+            "already trust by other means (e.g. network isolation).",
+            file=sys.stderr,
+        )
+    credentials.configure(trust_request_credentials=trust_request_credentials)
 
     if args.transport == "stdio":
         app.run()

--- a/mcp-server/tests/test_auth.py
+++ b/mcp-server/tests/test_auth.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import lib.auth as auth
+
+
+def test_no_provider_configured_by_default(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_KEYCLOAK_REALM_URL", raising=False)
+    assert auth.build_auth_provider() is None
+
+
+def test_keycloak_provider_built_when_realm_url_set(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_KEYCLOAK_REALM_URL", "https://keycloak.example.com/realms/myrealm")
+    provider = auth.build_auth_provider()
+    assert provider is not None
+    assert provider.issuer == "https://keycloak.example.com/realms/myrealm"
+    assert provider.jwks_uri == "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs"
+
+
+def test_keycloak_realm_url_trailing_slash_is_stripped(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_KEYCLOAK_REALM_URL", "https://keycloak.example.com/realms/myrealm/")
+    provider = auth.build_auth_provider()
+    assert provider.issuer == "https://keycloak.example.com/realms/myrealm"
+    assert "//protocol" not in provider.jwks_uri
+
+
+def test_keycloak_audience_is_optional(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_KEYCLOAK_REALM_URL", "https://keycloak.example.com/realms/myrealm")
+    monkeypatch.delenv("MCP_AUTH_KEYCLOAK_AUDIENCE", raising=False)
+    provider = auth.build_auth_provider()
+    assert provider.audience is None
+
+
+def test_keycloak_audience_is_passed_through_when_set(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_KEYCLOAK_REALM_URL", "https://keycloak.example.com/realms/myrealm")
+    monkeypatch.setenv("MCP_AUTH_KEYCLOAK_AUDIENCE", "my-mcp-server")
+    provider = auth.build_auth_provider()
+    assert provider.audience == "my-mcp-server"

--- a/mcp-server/tests/test_credentials.py
+++ b/mcp-server/tests/test_credentials.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import lib.credentials as credentials
+
+
+def _manifest(required_env=(), toolset="jira"):
+    return SimpleNamespace(toolset=toolset, required_environment_variables=required_env)
+
+
+def setup_function():
+    # credentials.configure() sets process-lifetime state -- reset it (and
+    # the one-shot warning flag) before every test so tests don't leak
+    # into each other via module-level state.
+    credentials.configure(trust_request_credentials=False)
+    credentials._warned_untrusted_headers_seen = False
+
+
+@patch("lib.credentials._get_http_headers", return_value={})
+def test_resolve_env_with_no_headers_uses_process_env(mock_headers, monkeypatch):
+    monkeypatch.setenv("JIRA_BASE_URL", "https://jira.example.com")
+    manifest = _manifest(required_env=({"name": "JIRA_BASE_URL", "required_for": "all functionality"},))
+    env = credentials.resolve_env(manifest, trust_request_credentials=False)
+    assert env["JIRA_BASE_URL"] == "https://jira.example.com"
+
+
+@patch(
+    "lib.credentials._get_http_headers",
+    return_value={"x-agent-skills-env-jira_password": "from-header"},
+)
+def test_untrusted_header_is_ignored_and_falls_back_to_process_env(mock_headers, monkeypatch):
+    monkeypatch.setenv("JIRA_PASSWORD", "from-process-env")
+    manifest = _manifest(required_env=({"name": "JIRA_PASSWORD", "required_for": "all functionality"},))
+    env = credentials.resolve_env(manifest, trust_request_credentials=False)
+    assert env["JIRA_PASSWORD"] == "from-process-env"
+
+
+@patch(
+    "lib.credentials._get_http_headers",
+    return_value={"x-agent-skills-env-jira_password": "from-header"},
+)
+def test_trusted_header_overrides_process_env(mock_headers, monkeypatch):
+    monkeypatch.setenv("JIRA_PASSWORD", "from-process-env")
+    manifest = _manifest(required_env=({"name": "JIRA_PASSWORD", "required_for": "all functionality"},))
+    env = credentials.resolve_env(manifest, trust_request_credentials=True)
+    assert env["JIRA_PASSWORD"] == "from-header"
+
+
+@patch(
+    "lib.credentials._get_http_headers",
+    return_value={"x-agent-skills-env-telegram_api_id": "999"},
+)
+def test_header_for_an_undeclared_var_is_never_injected_even_when_trusted(mock_headers, monkeypatch):
+    manifest = _manifest(required_env=({"name": "JIRA_BASE_URL", "required_for": "all functionality"},))
+    env = credentials.resolve_env(manifest, trust_request_credentials=True)
+    assert "TELEGRAM_API_ID" not in env
+
+
+@patch("lib.credentials._get_http_headers", return_value={})
+def test_env_is_scoped_to_declared_vars_not_the_whole_process_env(mock_headers, monkeypatch):
+    monkeypatch.setenv("JIRA_BASE_URL", "https://jira.example.com")
+    monkeypatch.setenv("TELEGRAM_API_ID", "some-other-toolsets-secret")
+    manifest = _manifest(required_env=({"name": "JIRA_BASE_URL", "required_for": "all functionality"},))
+    env = credentials.resolve_env(manifest, trust_request_credentials=False)
+    assert "TELEGRAM_API_ID" not in env
+
+
+@patch("lib.credentials._get_http_headers", return_value={})
+def test_infra_vars_pass_through_when_present(mock_headers, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    manifest = _manifest(required_env=())
+    env = credentials.resolve_env(manifest, trust_request_credentials=False)
+    assert env["PATH"] == "/usr/bin:/bin"
+
+
+def test_is_trusted_reflects_configure():
+    credentials.configure(trust_request_credentials=True)
+    assert credentials.is_trusted() is True
+    credentials.configure(trust_request_credentials=False)
+    assert credentials.is_trusted() is False
+
+
+def test_resolve_trust_cli_flag_wins(monkeypatch):
+    monkeypatch.delenv("MCP_TRUST_REQUEST_CREDENTIALS", raising=False)
+    assert credentials.resolve_trust_request_credentials(True) is True
+
+
+def test_resolve_trust_falls_back_to_env_var(monkeypatch):
+    monkeypatch.setenv("MCP_TRUST_REQUEST_CREDENTIALS", "1")
+    assert credentials.resolve_trust_request_credentials(False) is True
+
+
+def test_resolve_trust_defaults_false(monkeypatch):
+    monkeypatch.delenv("MCP_TRUST_REQUEST_CREDENTIALS", raising=False)
+    assert credentials.resolve_trust_request_credentials(False) is False

--- a/mcp-server/tests/test_execute.py
+++ b/mcp-server/tests/test_execute.py
@@ -130,3 +130,104 @@ def test_optional_env_var_never_blocks_execution(mock_run, tmp_path, monkeypatch
     result = execute_subcommand(manifest, SPEC, {"issue_key": "PAY-1", "duration": "2h"})
     assert result == {}
     mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------
+# Redaction: a value from a var marked sensitive: true in a toolset's own
+# required_environment_variables must never appear in an error payload,
+# regardless of which of the five error shapes fires. These use the
+# explicit `env=` parameter -- a testing seam, not something a real
+# caller passes -- so the injected secret is deterministic without
+# needing to touch os.environ or mock header resolution.
+# ---------------------------------------------------------------------
+
+_SENSITIVE_ENV = ({"name": "JIRA_PASSWORD", "required_for": "all functionality", "sensitive": True},)
+_SECRET_VALUE = "sekrit-value-should-never-leak"
+
+
+@patch("lib.execute.subprocess.run")
+def test_sensitive_value_redacted_from_nonzero_exit_stderr(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr=f"auth failed with password {_SECRET_VALUE}"
+    )
+    manifest = _manifest(tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py", required_env=_SENSITIVE_ENV)
+    result = execute_subcommand(
+        manifest, SPEC, {"issue_key": "PAY-1", "duration": "2h"}, env={"JIRA_PASSWORD": _SECRET_VALUE}
+    )
+    assert _SECRET_VALUE not in result["error"]["stderr"]
+    assert "REDACTED" in result["error"]["stderr"]
+
+
+@patch("lib.execute.subprocess.run")
+def test_sensitive_value_redacted_from_invalid_json_output(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=f"not json, password was {_SECRET_VALUE}", stderr=""
+    )
+    manifest = _manifest(tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py", required_env=_SENSITIVE_ENV)
+    result = execute_subcommand(
+        manifest, SPEC, {"issue_key": "PAY-1", "duration": "2h"}, env={"JIRA_PASSWORD": _SECRET_VALUE}
+    )
+    assert _SECRET_VALUE not in result["error"]["stdout"]
+
+
+@patch("lib.execute.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["x"], timeout=60))
+def test_sensitive_value_redacted_from_timeout_argv(mock_run, tmp_path):
+    manifest = _manifest(tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py", required_env=_SENSITIVE_ENV)
+    result = execute_subcommand(
+        manifest,
+        SPEC,
+        {"issue_key": "PAY-1", "duration": "2h"},
+        env={"JIRA_PASSWORD": _SECRET_VALUE},
+    )
+    assert all(_SECRET_VALUE not in a for a in result["error"]["argv"])
+
+
+@patch("lib.execute.subprocess.run", side_effect=OSError("no such file"))
+def test_sensitive_value_redacted_from_spawn_failed_argv(mock_run, tmp_path):
+    manifest = _manifest(tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py", required_env=_SENSITIVE_ENV)
+    result = execute_subcommand(
+        manifest, SPEC, {"issue_key": "PAY-1", "duration": "2h"}, env={"JIRA_PASSWORD": _SECRET_VALUE}
+    )
+    assert all(_SECRET_VALUE not in a for a in result["error"]["argv"])
+
+
+@patch("lib.execute.subprocess.run")
+def test_non_sensitive_var_is_never_redacted(mock_run, tmp_path):
+    """Redaction is opt-in per var (sensitive: true) -- a var like
+    JIRA_BASE_URL that isn't marked sensitive must pass through error
+    output untouched, so debugging isn't needlessly harder."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="could not reach https://jira.example.com"
+    )
+    manifest = _manifest(
+        tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py",
+        required_env=({"name": "JIRA_BASE_URL", "required_for": "all functionality"},),
+    )
+    result = execute_subcommand(
+        manifest,
+        SPEC,
+        {"issue_key": "PAY-1", "duration": "2h"},
+        env={"JIRA_BASE_URL": "https://jira.example.com"},
+    )
+    assert "https://jira.example.com" in result["error"]["stderr"]
+
+
+# ---------------------------------------------------------------------
+# Env scoping: a toolset's subprocess must never see another toolset's
+# declared credentials, even though they're both in the real os.environ.
+# ---------------------------------------------------------------------
+
+
+@patch("lib.execute.subprocess.run")
+def test_subprocess_env_excludes_other_toolsets_vars(mock_run, tmp_path, monkeypatch):
+    monkeypatch.setenv("JIRA_BASE_URL", "https://jira.example.com")
+    monkeypatch.setenv("TELEGRAM_API_ID", "some-other-toolsets-secret")
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+    manifest = _manifest(
+        tmp_path / "skills" / "jira" / "scripts" / "jira_tool.py",
+        required_env=({"name": "JIRA_BASE_URL", "required_for": "all functionality"},),
+    )
+    execute_subcommand(manifest, SPEC, {"issue_key": "PAY-1", "duration": "2h"})
+    actual_env = mock_run.call_args.kwargs["env"]
+    assert "TELEGRAM_API_ID" not in actual_env
+    assert actual_env["JIRA_BASE_URL"] == "https://jira.example.com"

--- a/mcp-server/tests/test_mcp_tools.py
+++ b/mcp-server/tests/test_mcp_tools.py
@@ -69,6 +69,34 @@ def test_build_tool_handler_calls_execute_subcommand(mock_execute):
     assert '"requires_confirmation":true' in result.content[0].text.replace(" ", "")
 
 
+def test_run_offloads_blocking_handler_so_concurrent_calls_overlap():
+    """GeneratedTool.run is `async def`, but its handler ends in a real
+    blocking subprocess.run() call -- being async alone doesn't stop
+    that from stalling the event loop. This proves two "slow" calls
+    actually run concurrently (wall time ~= one call's duration, not
+    the sum of both), not just that the code doesn't crash.
+    """
+    import time
+
+    manifest = SimpleNamespace(toolset="jira")
+    tool = build_tool("jira", manifest, SPEC)
+    tool.handler = lambda arguments: (time.sleep(0.2), {"ok": True})[1]
+
+    async def _run_two_concurrently():
+        start = time.monotonic()
+        await asyncio.gather(
+            tool.run({"issue_key": "PAY-1", "duration": "2h"}),
+            tool.run({"issue_key": "PAY-2", "duration": "2h"}),
+        )
+        return time.monotonic() - start
+
+    elapsed = asyncio.run(_run_two_concurrently())
+    # Sequential (blocking) execution would take >= 0.4s; overlapped
+    # execution takes ~0.2s. 0.35s leaves comfortable margin for CI
+    # scheduling jitter while still failing if this regresses to blocking.
+    assert elapsed < 0.35
+
+
 def test_register_toolset_tools_adds_one_tool_per_subcommand():
     fastmcp = pytest.importorskip("fastmcp")
     app = fastmcp.FastMCP(name="test")

--- a/mcp-server/tests/test_registry.py
+++ b/mcp-server/tests/test_registry.py
@@ -1,4 +1,33 @@
+from pathlib import Path
+
 from lib.registry import discover_skills, load_subcommands, resolve_include_internal
+
+
+def test_a_directory_with_no_skill_md_is_invisible_to_discovery(tmp_repo):
+    """The mechanism `skills/_shared/` relies on to never be discoverable
+    or installable as a skill (see its own README.md and AGENTS.md's
+    "Repo layout"): discover_skills() only considers a directory a skill
+    candidate if it has a SKILL.md at all -- a directory without one,
+    whatever its name, is never in the result, not specially excluded.
+    """
+    (tmp_repo / "skills" / "_shared").mkdir()
+    (tmp_repo / "skills" / "_shared" / "credentials").mkdir()
+    (tmp_repo / "skills" / "_shared" / "credentials" / "http.py").write_text("# not a skill\n")
+
+    manifests = discover_skills(tmp_repo, include_internal=False)
+    assert "_shared" not in {m.name for m in manifests}
+
+
+def test_the_real_shared_directory_has_no_skill_md():
+    """A direct check on this actual repo, not the synthetic tmp_repo --
+    the thing the test above proves is a general mechanism only matters
+    if skills/_shared/ itself never actually gets a SKILL.md. Catches an
+    accidental future addition (e.g. someone genuinely trying to make
+    _shared installable) failing loudly instead of silently starting to
+    work.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    assert not (repo_root / "skills" / "_shared" / "SKILL.md").exists()
 
 
 def test_jira_classified_as_toolset_root(tmp_repo):

--- a/skills/_shared/README.md
+++ b/skills/_shared/README.md
@@ -1,0 +1,52 @@
+# `_shared`
+
+**This directory is not a skill and must never contain a `SKILL.md`.**
+
+It holds code that more than one toolset symlinks into its own `lib/`, so a
+fix or an addition lands once instead of being hand-copied into every
+toolset that needs it.
+
+Both consumers this repo currently has visibility into discover skills by
+walking for `SKILL.md` presence, not by listing directory names under
+`skills/`:
+
+- This repo's own `mcp-server/lib/registry.py` builds its candidate list from
+  `entry.is_dir() and skill_md.exists()` -- a directory with none never enters
+  the list.
+- [`npx skills`](https://github.com/vercel-labs/skills)'s own `discoverSkills`
+  does the same.
+
+So a directory here with no `SKILL.md` is structurally invisible to both --
+not specially excluded, just never considered. `mcp-server/tests/test_registry.py`
+asserts this stays true; adding a `SKILL.md` here would fail that test on
+purpose.
+
+## Layout
+
+```
+credentials/
+└── http.py   # Credential protocol + BasicCredential/BearerCredential/
+              # NoCredential -- the HTTP-session family. Used by any
+              # toolset that authenticates a `requests.Session` (Jira
+              # today; Confluence and GitLab's REST/GraphQL APIs fit the
+              # same shape).
+```
+
+A toolset that needs one of these files symlinks it into its own `lib/`,
+e.g.:
+
+```bash
+ln -s ../../_shared/credentials/http.py skills/jira/lib/credentials.py
+```
+
+**Windows note:** if a checkout has `git config core.symlinks false` (some
+older Git-for-Windows setups without Developer Mode), a symlink materializes
+as a plain text file containing the target path instead of a real symlink --
+`credentials.py` would then be a one-line text file, not code. Enable
+Developer Mode (or run `git config core.symlinks true` before cloning) if
+you hit an import error here on Windows.
+
+A structurally different credential shape (e.g. a future `git`-the-CLI
+toolset, which needs SSH keys or a credential helper, not a value applied to
+an HTTP session) gets its own module here when that toolset actually exists
+-- not stubbed out speculatively ahead of it.

--- a/skills/_shared/credentials/http.py
+++ b/skills/_shared/credentials/http.py
@@ -1,0 +1,89 @@
+"""Credentials for toolsets that authenticate an HTTP `requests.Session`.
+
+A toolset never constructs one of these to match its own env vars' shape
+-- it reads whichever env vars it declares (`JIRA_USERNAME`/`JIRA_PASSWORD`,
+a future `JIRA_PAT`, `CONFLUENCE_TOKEN`, ...) and builds whichever
+concrete `Credential` fits what was actually configured. The toolset's
+own request code then only ever calls `credential.apply(session)` --
+it doesn't know or care whether that credential came from this
+process's own environment (personal/direct use) or was resolved
+per-request by `mcp-server` on behalf of one specific caller behind a
+multi-user chat client. That indifference is the entire point: the same
+toolset code serves both.
+
+This module is symlinked, not copied, into every toolset that needs it
+-- see `../README.md`. Keep it dependency-light and toolset-agnostic;
+anything specific to one toolset's own env var names belongs in that
+toolset's own `lib/auth.py`, not here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import requests
+
+
+@runtime_checkable
+class Credential(Protocol):
+    """Something that knows how to authenticate an outgoing HTTP request.
+
+    Concrete implementations below cover HTTP Basic auth and a single
+    bearer token (which itself covers a Personal Access Token, a plain
+    API key, and an OAuth access token -- identical wire format, so one
+    type serves all three, see `BearerCredential`).
+    """
+
+    def apply(self, session: "requests.Session") -> None:
+        """Configure `session` so subsequent requests are authenticated."""
+        ...
+
+
+class BasicCredential:
+    """HTTP Basic auth -- a username/password pair."""
+
+    __slots__ = ("username", "password")
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+    def apply(self, session: "requests.Session") -> None:
+        session.auth = (self.username, self.password)
+
+    def __repr__(self) -> str:  # never expose the password, even in logs
+        return f"BasicCredential(username={self.username!r})"
+
+
+class BearerCredential:
+    """A single opaque token sent as `Authorization: Bearer <token>`.
+
+    Covers a Jira Data Center Personal Access Token, a plain API key
+    (e.g. a GitLab PAT -- GitLab's own docs confirm `Authorization:
+    Bearer <token>` works for its REST API, not only its `PRIVATE-TOKEN`
+    header), and an OAuth access token: the wire format is identical in
+    all three cases.
+    """
+
+    __slots__ = ("token",)
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def apply(self, session: "requests.Session") -> None:
+        session.headers["Authorization"] = f"Bearer {self.token}"
+
+    def __repr__(self) -> str:  # never expose the token, even in logs
+        return "BearerCredential(token=***)"
+
+
+class NoCredential:
+    """No authentication at all, for an endpoint that genuinely needs
+    none. Applying it is a deliberate no-op, not something forgotten."""
+
+    def apply(self, session: "requests.Session") -> None:
+        return None
+
+    def __repr__(self) -> str:
+        return "NoCredential()"

--- a/skills/jira/README.md
+++ b/skills/jira/README.md
@@ -168,8 +168,9 @@ ever hard-coded.**
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `JIRA_BASE_URL` | Yes | -- | Root URL of your Jira instance, e.g. `https://jira.mycompany.com` |
-| `JIRA_USERNAME` | Yes | -- | Basic-auth username |
-| `JIRA_PASSWORD` | Yes | -- | Basic-auth password |
+| `JIRA_USERNAME` | Yes\*\* | -- | Basic-auth username -- set together with `JIRA_PASSWORD`, or use `JIRA_PAT` instead |
+| `JIRA_PASSWORD` | Yes\*\* | -- | Basic-auth password -- set together with `JIRA_USERNAME`, or use `JIRA_PAT` instead |
+| `JIRA_PAT` | Yes\*\* | -- | A Personal Access Token or other bearer token, sent as `Authorization: Bearer <token>`. Alternative to `JIRA_USERNAME`/`JIRA_PASSWORD`; takes precedence if both are set. \*\*Exactly one auth mode must be configured: `JIRA_PAT`, or both `JIRA_USERNAME` and `JIRA_PASSWORD` |
 | `JIRA_TIMEOUT_SECONDS` | No | `30` | Per-request timeout |
 | `JIRA_MAX_RETRIES` | No | `3` | Retries for `429`/`5xx` responses |
 | `JIRA_VERIFY_SSL` | No | `true` | Disable only for trusted self-signed internal instances |
@@ -178,15 +179,32 @@ ever hard-coded.**
 | `JIRA_DEFAULT_PROJECT` | No | -- | Project key (e.g. `PAYKAN`) used by `triage` when `--project` isn't given; if unset, the model must resolve/pass a project itself |
 | `JIRA_DEPLOYMENT_TYPE` | No\* | -- | `cloud` or `server` (the latter also covers Data Center). \*Required the first time `create_issue`/`edit_issue` sets an assignee -- Jira Cloud identifies users by `accountId`, Server/Data Center by username, and the two shapes aren't interchangeable |
 
-Configuration is validated eagerly: `lib.auth.load_config()` raises a
-`ConfigurationError` with a specific, actionable message if required
-variables are missing (e.g. `JIRA_PASSWORD` not set). Wire this into
-whatever startup/health check your runtime supports so misconfiguration
-fails fast instead of at first tool call.
+Configuration is validated eagerly: `lib.auth.load_config()` (behavioral
+settings) and `lib.auth.load_credential()` (auth) each raise a
+`ConfigurationError` with a specific, actionable message if something's
+missing or inconsistent (e.g. neither `JIRA_PAT` nor a complete
+`JIRA_USERNAME`/`JIRA_PASSWORD` pair is set). `scripts/jira_tool.py`'s
+`main()` catches this and prints it as a clean `{"error": {...}}` JSON
+document rather than a raw traceback -- same as every other error this
+skill's tools produce. Wire the eager check into whatever startup/health
+check your runtime supports so misconfiguration fails fast instead of at
+first tool call.
 
-This skill only supports HTTP Basic auth (`JIRA_USERNAME` +
-`JIRA_PASSWORD`), which works against both Jira Cloud and self-hosted
-Jira Server/Data Center.
+This skill supports two auth modes, either of which works against both
+Jira Cloud and self-hosted Jira Server/Data Center:
+
+- **HTTP Basic** (`JIRA_USERNAME` + `JIRA_PASSWORD`) -- the original,
+  still-default mode.
+- **A single bearer token** (`JIRA_PAT`), sent as `Authorization: Bearer
+  <token>` -- a Jira Data Center Personal Access Token (8.14+), a Jira
+  Cloud API token used as a bearer token, or any other credential that
+  fits the same shape. Takes precedence over Basic auth if both happen
+  to be set.
+
+Credential handling itself (`Credential`/`BasicCredential`/
+`BearerCredential`) lives in `skills/_shared/credentials/http.py` and is
+symlinked into `lib/credentials.py` -- see that directory's own
+`README.md` for why, and for the Windows caveat on symlinked checkouts.
 
 ## Tools
 

--- a/skills/jira/SKILL.md
+++ b/skills/jira/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   and reasoning over their JSON output, never by guessing or inventing
   ticket data. Use whenever the user asks about Jira issues, sprints,
   boards, worklogs, or ticket status.
-version: 1.1.0
+version: 1.2.0
 metadata:
   category: software-development
   hermes:
@@ -19,11 +19,17 @@ required_environment_variables:
     prompt: "Jira base URL (e.g. https://jira.mycompany.com)"
     required_for: all functionality
   - name: JIRA_USERNAME
-    prompt: "Jira username"
-    required_for: all functionality
+    prompt: "Jira username (for Basic auth -- skip if using JIRA_PAT instead)"
+    required_for: optional -- required together with JIRA_PASSWORD unless JIRA_PAT is set
+    sensitive: true
   - name: JIRA_PASSWORD
-    prompt: "Jira password"
-    required_for: all functionality
+    prompt: "Jira password (for Basic auth -- skip if using JIRA_PAT instead)"
+    required_for: optional -- required together with JIRA_USERNAME unless JIRA_PAT is set
+    sensitive: true
+  - name: JIRA_PAT
+    prompt: "Jira Personal Access Token or other bearer token (alternative to JIRA_USERNAME/JIRA_PASSWORD)"
+    required_for: optional -- alternative to JIRA_USERNAME/JIRA_PASSWORD; takes precedence if both are set
+    sensitive: true
   - name: JIRA_AUTO_CONFIRM_WRITES
     prompt: "Skip the confirm step before logging work / transitioning / creating / editing tickets? (true/false)"
     required_for: optional, defaults to false (asks before every write)

--- a/skills/jira/lib/auth.py
+++ b/skills/jira/lib/auth.py
@@ -1,8 +1,19 @@
 """Authentication and configuration handling for the Jira Assistant skill.
 
 Credentials are always sourced from environment variables. No credentials
-may be hard-coded or embedded in source. Only HTTP Basic auth
-(username + password) is supported.
+may be hard-coded or embedded in source. Two auth modes are supported:
+HTTP Basic (username + password) and a single bearer token (a Jira Data
+Center Personal Access Token, or an OAuth access token if one is ever
+supplied this way) -- see `load_credential()`.
+
+Credential material (`load_credential()`, returning a
+`lib.credentials.Credential`) is deliberately kept separate from
+`JiraConfig`, which holds only *behavioral* settings (timeouts, retries,
+which project to default to, ...). `JiraClient` accepts whichever
+`Credential` it's handed and never inspects how it was obtained --
+whether that's this process's own environment (personal/direct use) or
+a credential resolved per-request by `mcp-server` on behalf of one
+specific caller behind a multi-user chat client.
 """
 
 from __future__ import annotations
@@ -11,6 +22,8 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import Mapping, Optional
+
+from .credentials import BasicCredential, BearerCredential, Credential
 
 logger = logging.getLogger("jira_skill.auth")
 
@@ -23,10 +36,12 @@ class ConfigurationError(RuntimeError):
 class JiraConfig:
     """Validated runtime configuration for the Jira client.
 
+    Deliberately holds no credential material -- see `load_credential()`
+    for that. Everything here is a behavioral setting, independent of
+    which auth mode is in use.
+
     Attributes:
         base_url: Root URL of the Jira instance, e.g. ``https://jira.example.com``.
-        username: Basic-auth username.
-        password: Basic-auth password.
         timeout_seconds: Per-request network timeout.
         max_retries: Maximum retry attempts for idempotent/rate-limited requests.
         verify_ssl: Whether to verify TLS certificates (disable only for
@@ -48,18 +63,12 @@ class JiraConfig:
     """
 
     base_url: str
-    username: str
-    password: str
     timeout_seconds: float = 30.0
     max_retries: int = 3
     verify_ssl: bool = True
     auto_confirm_writes: bool = False
     default_project: Optional[str] = None
     deployment_type: Optional[str] = None
-
-    def auth_summary(self) -> str:
-        """Return a redacted, human-readable description of the auth mode."""
-        return f"Basic auth (user={self.username})"
 
 
 def _env(source: Mapping[str, str], name: str, default: Optional[str] = None) -> Optional[str]:
@@ -96,8 +105,54 @@ def _env_int(source: Mapping[str, str], name: str, default: int) -> int:
         raise ConfigurationError(f"Environment variable {name}={raw!r} is not a valid integer") from exc
 
 
+def load_credential(env: Optional[Mapping[str, str]] = None) -> Credential:
+    """Load and validate Jira auth credentials from environment variables.
+
+    Two modes, checked in this order:
+
+    1. ``JIRA_PAT`` set -- a bearer token (a Jira Data Center Personal
+       Access Token, or any other single-token credential the deployment
+       hands this skill the same way). Takes precedence over Basic auth
+       if both happen to be set, since a PAT is the more specific choice
+       when someone has gone to the trouble of minting one.
+    2. ``JIRA_USERNAME`` + ``JIRA_PASSWORD`` both set -- HTTP Basic auth.
+
+    Args:
+        env: Optional explicit mapping to read from instead of the
+            process environment (primarily for testing, and this is
+            also the seam `mcp-server` uses to hand this skill a
+            per-request credential instead of its own process env).
+
+    Raises:
+        ConfigurationError: If neither mode is fully configured. The
+            message names both options so operators aren't left
+            guessing which env vars to set.
+    """
+    source: Mapping[str, str] = env if env is not None else os.environ
+
+    pat = _env(source, "JIRA_PAT")
+    if pat:
+        return BearerCredential(token=pat)
+
+    username = _env(source, "JIRA_USERNAME")
+    password = _env(source, "JIRA_PASSWORD")
+    if username and password:
+        return BasicCredential(username=username, password=password)
+
+    missing = [name for name, value in (("JIRA_USERNAME", username), ("JIRA_PASSWORD", password)) if not value]
+    raise ConfigurationError(
+        "No Jira credential configured. Set either JIRA_PAT (a Personal "
+        "Access Token or other bearer token), or both JIRA_USERNAME and "
+        "JIRA_PASSWORD for Basic auth. Currently missing: "
+        f"{', '.join(missing) if missing else 'JIRA_USERNAME, JIRA_PASSWORD'} "
+        "(and JIRA_PAT is not set)."
+    )
+
+
 def load_config(env: Optional[Mapping[str, str]] = None) -> JiraConfig:
-    """Load and validate Jira configuration from environment variables.
+    """Load and validate Jira behavioral configuration from environment
+    variables. Does not touch credential material -- see
+    `load_credential()` for that.
 
     Args:
         env: Optional explicit mapping to read from instead of the
@@ -110,7 +165,6 @@ def load_config(env: Optional[Mapping[str, str]] = None) -> JiraConfig:
 
     Environment variables:
         JIRA_BASE_URL (required): Root URL of the Jira instance.
-        JIRA_USERNAME / JIRA_PASSWORD (required): Basic-auth credentials.
         JIRA_TIMEOUT_SECONDS (optional, default 30).
         JIRA_MAX_RETRIES (optional, default 3).
         JIRA_VERIFY_SSL (optional, default true).
@@ -133,18 +187,6 @@ def load_config(env: Optional[Mapping[str, str]] = None) -> JiraConfig:
             f"JIRA_BASE_URL={base_url!r} must start with http:// or https://"
         )
 
-    username = _env(source, "JIRA_USERNAME")
-    password = _env(source, "JIRA_PASSWORD")
-    missing = [
-        name
-        for name, value in (("JIRA_USERNAME", username), ("JIRA_PASSWORD", password))
-        if not value
-    ]
-    if missing:
-        raise ConfigurationError(
-            f"The following environment variables are missing: {', '.join(missing)}"
-        )
-
     deployment_type_raw = _env(source, "JIRA_DEPLOYMENT_TYPE")
     deployment_type = None
     if deployment_type_raw:
@@ -157,8 +199,6 @@ def load_config(env: Optional[Mapping[str, str]] = None) -> JiraConfig:
 
     config = JiraConfig(
         base_url=base_url,
-        username=username,
-        password=password,
         timeout_seconds=_env_float(source, "JIRA_TIMEOUT_SECONDS", 30.0),
         max_retries=_env_int(source, "JIRA_MAX_RETRIES", 3),
         verify_ssl=_env_bool(source, "JIRA_VERIFY_SSL", True),
@@ -166,10 +206,5 @@ def load_config(env: Optional[Mapping[str, str]] = None) -> JiraConfig:
         default_project=_env(source, "JIRA_DEFAULT_PROJECT"),
         deployment_type=deployment_type,
     )
-    logger.info(
-        "Loaded Jira configuration: base_url=%s auth=%s auto_confirm_writes=%s",
-        config.base_url,
-        config.auth_summary(),
-        config.auto_confirm_writes,
-    )
+    logger.info("Loaded Jira configuration: base_url=%s auto_confirm_writes=%s", config.base_url, config.auto_confirm_writes)
     return config

--- a/skills/jira/lib/credentials.py
+++ b/skills/jira/lib/credentials.py
@@ -1,0 +1,1 @@
+../../_shared/credentials/http.py

--- a/skills/jira/lib/jira_client.py
+++ b/skills/jira/lib/jira_client.py
@@ -7,7 +7,9 @@ error normalization, and (optional) response caching, so that behavior is
 consistent everywhere and never duplicated.
 
 Supports both Jira Cloud and self-hosted Jira Server / Data Center via an
-explicit ``base_url``, using HTTP Basic auth (username + password).
+explicit ``base_url``, using either HTTP Basic auth (username + password)
+or a single bearer token (a Personal Access Token, or any other
+single-token credential) -- see ``lib.auth.load_credential``.
 """
 
 from __future__ import annotations
@@ -22,7 +24,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .auth import JiraConfig, load_config
+from .auth import JiraConfig, load_config, load_credential
+from .credentials import Credential
 from .models import (
     Board,
     ChangelogEntry,
@@ -240,15 +243,19 @@ class JiraClient:
     def __init__(
         self,
         config: Optional[JiraConfig] = None,
+        credential: Optional[Credential] = None,
         session: Optional[requests.Session] = None,
         cache_ttl_seconds: Optional[float] = None,
     ):
         self.config = config or load_config()
+        self.credential = credential or load_credential()
         self.session = session or self._build_session()
         if cache_ttl_seconds is None:
             cache_ttl_seconds = float(os.environ.get("JIRA_CACHE_TTL_SECONDS", "0") or 0)
         self._cache = _TTLCache(cache_ttl_seconds)
-        logger.debug("JiraClient initialized against %s", self.config.base_url)
+        logger.debug(
+            "JiraClient initialized against %s using %r", self.config.base_url, self.credential
+        )
 
     # ------------------------------------------------------------------
     # Session / transport setup
@@ -269,7 +276,7 @@ class JiraClient:
         session.mount("https://", adapter)
         session.headers.update({"Accept": "application/json", "Content-Type": "application/json"})
 
-        session.auth = (self.config.username, self.config.password)
+        self.credential.apply(session)
         session.verify = self.config.verify_ssl
         return session
 
@@ -337,8 +344,8 @@ class JiraClient:
 
         if status == 401:
             raise JiraAuthError(
-                f"Jira authentication failed (401). Check JIRA_USERNAME/JIRA_PASSWORD. "
-                f"Details: {message}",
+                f"Jira authentication failed (401). Check JIRA_USERNAME/JIRA_PASSWORD "
+                f"or JIRA_PAT. Details: {message}",
                 status_code=status,
             )
         if status == 403:

--- a/skills/jira/scripts/jira_tool.py
+++ b/skills/jira/scripts/jira_tool.py
@@ -51,6 +51,7 @@ _SKILL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _SKILL_ROOT not in sys.path:
     sys.path.insert(0, _SKILL_ROOT)
 
+from lib.auth import ConfigurationError  # noqa: E402
 from tools import (  # noqa: E402
     blockers,
     create_issue,
@@ -404,7 +405,23 @@ def dispatch(args: argparse.Namespace):
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    result = dispatch(args)
+    # Every actual tool body already runs inside tools/_common.py's
+    # run_tool(), which catches everything (including ConfigurationError,
+    # e.g. from lib.auth.load_credential()) and returns a clean
+    # {"error": {...}} dict -- this call practically never sees an
+    # exception in normal operation. This try/except exists for whatever
+    # is NOT inside a tool's own run_tool()-wrapped closure -- e.g.
+    # dispatch()'s final `raise AssertionError("Unhandled tool: ...")`,
+    # marked unreachable but still worth catching rather than trusting --
+    # so this script's documented contract (see module docstring: one
+    # JSON document, always, never a raw traceback) holds even outside
+    # run_tool()'s coverage, not just within it.
+    try:
+        result = dispatch(args)
+    except ConfigurationError as exc:
+        result = {"error": {"type": "configuration_error", "message": str(exc)}}
+    except Exception as exc:  # noqa: BLE001 -- last-resort safety net, see comment above
+        result = {"error": {"type": "internal_error", "message": f"{type(exc).__name__}: {exc}"}}
     print(json.dumps(result, indent=2, default=str))
     return 0
 

--- a/skills/jira/tests/conftest.py
+++ b/skills/jira/tests/conftest.py
@@ -9,6 +9,7 @@ if SKILL_ROOT not in sys.path:
     sys.path.insert(0, SKILL_ROOT)
 
 from lib.auth import JiraConfig  # noqa: E402
+from lib.credentials import BasicCredential  # noqa: E402
 from lib.jira_client import JiraClient, reset_client  # noqa: E402
 
 
@@ -16,10 +17,13 @@ from lib.jira_client import JiraClient, reset_client  # noqa: E402
 def jira_config() -> JiraConfig:
     return JiraConfig(
         base_url="https://jira.example.com",
-        username="alice",
-        password="secret",
         max_retries=0,
     )
+
+
+@pytest.fixture
+def jira_credential() -> BasicCredential:
+    return BasicCredential(username="alice", password="secret")
 
 
 @pytest.fixture
@@ -28,8 +32,8 @@ def mock_session():
 
 
 @pytest.fixture
-def client(jira_config, mock_session) -> JiraClient:
-    return JiraClient(config=jira_config, session=mock_session)
+def client(jira_config, jira_credential, mock_session) -> JiraClient:
+    return JiraClient(config=jira_config, credential=jira_credential, session=mock_session)
 
 
 @pytest.fixture(autouse=True)

--- a/skills/jira/tests/test_auth.py
+++ b/skills/jira/tests/test_auth.py
@@ -3,47 +3,23 @@ import pytest
 from lib.auth import ConfigurationError, load_config
 
 
-def test_basic_auth_loads_successfully():
-    config = load_config(
-        env={
-            "JIRA_BASE_URL": "https://jira.example.com/",
-            "JIRA_USERNAME": "alice",
-            "JIRA_PASSWORD": "secret",
-        }
-    )
+def test_base_url_loads_successfully():
+    config = load_config(env={"JIRA_BASE_URL": "https://jira.example.com/"})
     assert config.base_url == "https://jira.example.com"
-    assert config.username == "alice"
 
 
 def test_missing_base_url_raises():
     with pytest.raises(ConfigurationError, match="JIRA_BASE_URL"):
-        load_config(env={"JIRA_USERNAME": "alice", "JIRA_PASSWORD": "secret"})
+        load_config(env={})
 
 
 def test_base_url_without_scheme_raises():
     with pytest.raises(ConfigurationError, match="http"):
-        load_config(
-            env={
-                "JIRA_BASE_URL": "jira.example.com",
-                "JIRA_USERNAME": "alice",
-                "JIRA_PASSWORD": "secret",
-            }
-        )
-
-
-def test_basic_auth_missing_username_raises():
-    with pytest.raises(ConfigurationError, match="JIRA_USERNAME"):
-        load_config(env={"JIRA_BASE_URL": "https://jira.example.com", "JIRA_PASSWORD": "secret"})
+        load_config(env={"JIRA_BASE_URL": "jira.example.com"})
 
 
 def test_auto_confirm_writes_defaults_false():
-    config = load_config(
-        env={
-            "JIRA_BASE_URL": "https://jira.example.com",
-            "JIRA_USERNAME": "alice",
-            "JIRA_PASSWORD": "secret",
-        }
-    )
+    config = load_config(env={"JIRA_BASE_URL": "https://jira.example.com"})
     assert config.auto_confirm_writes is False
 
 
@@ -51,8 +27,6 @@ def test_auto_confirm_writes_can_be_enabled():
     config = load_config(
         env={
             "JIRA_BASE_URL": "https://jira.example.com",
-            "JIRA_USERNAME": "alice",
-            "JIRA_PASSWORD": "secret",
             "JIRA_AUTO_CONFIRM_WRITES": "true",
         }
     )
@@ -60,13 +34,7 @@ def test_auto_confirm_writes_can_be_enabled():
 
 
 def test_deployment_type_defaults_unset():
-    config = load_config(
-        env={
-            "JIRA_BASE_URL": "https://jira.example.com",
-            "JIRA_USERNAME": "alice",
-            "JIRA_PASSWORD": "secret",
-        }
-    )
+    config = load_config(env={"JIRA_BASE_URL": "https://jira.example.com"})
     assert config.deployment_type is None
 
 
@@ -75,8 +43,6 @@ def test_deployment_type_accepted_case_insensitively(raw, expected):
     config = load_config(
         env={
             "JIRA_BASE_URL": "https://jira.example.com",
-            "JIRA_USERNAME": "alice",
-            "JIRA_PASSWORD": "secret",
             "JIRA_DEPLOYMENT_TYPE": raw,
         }
     )
@@ -88,8 +54,6 @@ def test_deployment_type_rejects_unknown_value():
         load_config(
             env={
                 "JIRA_BASE_URL": "https://jira.example.com",
-                "JIRA_USERNAME": "alice",
-                "JIRA_PASSWORD": "secret",
                 "JIRA_DEPLOYMENT_TYPE": "datacenter",
             }
         )

--- a/skills/jira/tests/test_credentials.py
+++ b/skills/jira/tests/test_credentials.py
@@ -1,0 +1,79 @@
+"""Tests for lib.auth.load_credential() and the shared Credential types
+it returns (lib.credentials, symlinked from skills/_shared/credentials/http.py
+-- these tests exercise them through that real symlinked import path, the
+same way production code does).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.auth import ConfigurationError, load_credential
+from lib.credentials import BasicCredential, BearerCredential, NoCredential
+
+
+def test_basic_credential_loads_from_username_and_password():
+    credential = load_credential(env={"JIRA_USERNAME": "alice", "JIRA_PASSWORD": "secret"})
+    assert isinstance(credential, BasicCredential)
+    assert credential.username == "alice"
+    assert credential.password == "secret"
+
+
+def test_bearer_credential_loads_from_pat():
+    credential = load_credential(env={"JIRA_PAT": "sometoken"})
+    assert isinstance(credential, BearerCredential)
+    assert credential.token == "sometoken"
+
+
+def test_pat_takes_precedence_over_basic_when_both_set():
+    credential = load_credential(
+        env={"JIRA_PAT": "sometoken", "JIRA_USERNAME": "alice", "JIRA_PASSWORD": "secret"}
+    )
+    assert isinstance(credential, BearerCredential)
+
+
+def test_missing_both_modes_raises_naming_both_options():
+    with pytest.raises(ConfigurationError, match="JIRA_PAT"):
+        load_credential(env={})
+
+
+def test_partial_basic_missing_password_raises():
+    with pytest.raises(ConfigurationError, match="JIRA_PASSWORD"):
+        load_credential(env={"JIRA_USERNAME": "alice"})
+
+
+def test_partial_basic_missing_username_raises():
+    with pytest.raises(ConfigurationError, match="JIRA_USERNAME"):
+        load_credential(env={"JIRA_PASSWORD": "secret"})
+
+
+def test_basic_credential_apply_sets_session_auth():
+    session = MagicMock()
+    BasicCredential(username="alice", password="secret").apply(session)
+    assert session.auth == ("alice", "secret")
+
+
+def test_bearer_credential_apply_sets_authorization_header():
+    session = MagicMock()
+    session.headers = {}
+    BearerCredential(token="sometoken").apply(session)
+    assert session.headers["Authorization"] == "Bearer sometoken"
+
+
+def test_no_credential_apply_is_a_pure_noop():
+    session = MagicMock()
+    result = NoCredential().apply(session)
+    assert result is None
+    # A real assignment (as BasicCredential does) would make session.auth a
+    # tuple; NoCredential must never touch it at all.
+    assert not isinstance(session.auth, tuple)
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [BasicCredential(username="alice", password="hunter2"), BearerCredential(token="sk-secretvalue")],
+)
+def test_credential_repr_never_exposes_the_secret(credential):
+    text = repr(credential)
+    assert "hunter2" not in text
+    assert "sk-secretvalue" not in text

--- a/skills/jira/tests/test_jira_client.py
+++ b/skills/jira/tests/test_jira_client.py
@@ -295,12 +295,12 @@ def test_triage_requires_a_project(client):
         client.triage()
 
 
-def test_triage_uses_default_project_from_config(jira_config, mock_session):
+def test_triage_uses_default_project_from_config(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     mock_session.request.side_effect = [
         make_response(json_data={"issues": []}),
         make_response(json_data={"issues": []}),
@@ -404,12 +404,12 @@ def test_search_users_scoped_by_explicit_project_hits_assignable_search(client, 
     assert kwargs["params"]["username"] == "sam"
 
 
-def test_search_users_scoped_by_default_project_from_config(jira_config, mock_session):
+def test_search_users_scoped_by_default_project_from_config(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     mock_session.request.return_value = make_response(json_data=[])
     configured_client.search_users("sam")
     method, url = mock_session.request.call_args[0][:2]
@@ -418,24 +418,24 @@ def test_search_users_scoped_by_default_project_from_config(jira_config, mock_se
     assert kwargs["params"]["project"] == "PAYKAN"
 
 
-def test_search_users_explicit_project_overrides_default_project(jira_config, mock_session):
+def test_search_users_explicit_project_overrides_default_project(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     mock_session.request.return_value = make_response(json_data=[])
     configured_client.search_users("sam", project="OTHER")
     _, kwargs = mock_session.request.call_args
     assert kwargs["params"]["project"] == "OTHER"
 
 
-def test_search_users_all_projects_ignores_explicit_and_default_project(jira_config, mock_session):
+def test_search_users_all_projects_ignores_explicit_and_default_project(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     mock_session.request.return_value = make_response(json_data=[])
     configured_client.search_users("sam", project="OTHER", all_projects=True)
     method, url = mock_session.request.call_args[0][:2]
@@ -448,12 +448,12 @@ def test_resolve_project_returns_none_when_neither_given(client):
     assert client.resolve_project(None) is None
 
 
-def test_resolve_project_falls_back_to_config_default(jira_config, mock_session):
+def test_resolve_project_falls_back_to_config_default(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     assert configured_client.resolve_project(None) == "PAYKAN"
     assert configured_client.resolve_project("OTHER") == "OTHER"
 
@@ -472,12 +472,12 @@ def test_create_issue_subtask_requires_parent_key(client):
         client.create_issue("PAYKAN", "Build UI", "Sub-task")
 
 
-def test_create_issue_builds_request_body_and_refetches(jira_config, mock_session):
+def test_create_issue_builds_request_body_and_refetches(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    cloud_client = JiraClient(config=replace(jira_config, deployment_type="cloud"), session=mock_session)
+    cloud_client = JiraClient(config=replace(jira_config, deployment_type="cloud"), credential=jira_credential, session=mock_session)
     create_response = make_response(status_code=201, json_data={"key": "PAYKAN-500"})
     get_response = make_response(
         json_data={"key": "PAYKAN-500", "fields": {"summary": "Build UI", "status": {"name": "To Do"}}}
@@ -515,12 +515,12 @@ def test_create_issue_builds_request_body_and_refetches(jira_config, mock_sessio
     }
 
 
-def test_create_issue_assignee_uses_name_field_on_server(jira_config, mock_session):
+def test_create_issue_assignee_uses_name_field_on_server(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    server_client = JiraClient(config=replace(jira_config, deployment_type="server"), session=mock_session)
+    server_client = JiraClient(config=replace(jira_config, deployment_type="server"), credential=jira_credential, session=mock_session)
     create_response = make_response(status_code=201, json_data={"key": "PAYKAN-500"})
     get_response = make_response(
         json_data={"key": "PAYKAN-500", "fields": {"summary": "Build UI", "status": {"name": "To Do"}}}
@@ -588,12 +588,12 @@ def test_edit_issue_sends_only_provided_fields_and_refetches(client, mock_sessio
     assert put_call.kwargs["json"] == {"fields": {"summary": "New title"}}
 
 
-def test_edit_issue_assignee_uses_name_field_on_server(jira_config, mock_session):
+def test_edit_issue_assignee_uses_name_field_on_server(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    server_client = JiraClient(config=replace(jira_config, deployment_type="server"), session=mock_session)
+    server_client = JiraClient(config=replace(jira_config, deployment_type="server"), credential=jira_credential, session=mock_session)
     put_response = make_response(status_code=204)
     get_response = make_response(
         json_data={"key": "PAYKAN-1", "fields": {"summary": "New title", "status": {"name": "To Do"}}}
@@ -702,12 +702,12 @@ def _empty_project_context_responses(project_name="Payment Platform", lead="Alic
     ]
 
 
-def test_project_context_uses_default_project_from_config(jira_config, mock_session):
+def test_project_context_uses_default_project_from_config(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
-    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), session=mock_session)
+    configured_client = JiraClient(config=replace(jira_config, default_project="PAYKAN"), credential=jira_credential, session=mock_session)
     mock_session.request.side_effect = _empty_project_context_responses()
     result = configured_client.project_context()
     assert result["project"] == "PAYKAN"
@@ -822,13 +822,13 @@ def test_current_board_scopes_lookup_to_resolved_project(client, mock_session):
     assert kwargs["params"]["projectKeyOrId"] == "PAYKAN"
 
 
-def test_current_board_falls_back_to_default_project_from_config(jira_config, mock_session):
+def test_current_board_falls_back_to_default_project_from_config(jira_config, jira_credential, mock_session):
     from dataclasses import replace
 
     from lib.jira_client import JiraClient
 
     config = replace(jira_config, default_project="PAYKAN")
-    client = JiraClient(config=config, session=mock_session)
+    client = JiraClient(config=config, credential=jira_credential, session=mock_session)
     mock_session.request.return_value = make_response(
         json_data={"values": [{"id": 4, "name": "PAYKAN board", "type": "kanban"}]}
     )

--- a/skills/jira/tests/test_tools.py
+++ b/skills/jira/tests/test_tools.py
@@ -51,8 +51,6 @@ def _issue(
 def _fake_config(auto_confirm=False):
     return JiraConfig(
         base_url="https://jira.example.com",
-        username="alice",
-        password="secret",
         auto_confirm_writes=auto_confirm,
     )
 


### PR DESCRIPTION
## What this does

Closes the gap where `mcp-server` was single-tenant by construction:
one process, one env var, every caller sharing one identity against
Jira regardless of who's actually asking. Governing principle
throughout: **`agent-skills` is a credential conduit, never a
credential store** — it accepts a credential for one call and uses it,
nothing persisted, nothing enrolled.

Personal/direct use (Claude Code, Hermes, claude.ai reading `SKILL.md`
natively) is untouched — same env vars, same behavior, verified
end-to-end, not just asserted.

## Commits, in dependency order

1. **`14fa814`** — Split Jira's credential material from its behavioral
   config. `Credential`/`BasicCredential`/`BearerCredential` live in
   `skills/_shared/credentials/http.py`, **symlinked** (not copied) into
   Jira — verified this survives both `git clone` and `npx skills add
   --skill jira` by reading the installer's actual source, not assuming.
   Adds `JIRA_PAT` as a Bearer alternative to Basic auth.
2. **`36f958f`** — `mcp-server` resolves each subprocess's environment
   per call instead of `os.environ.copy()`: scoped to infra vars + only
   the calling toolset's own declared vars (no more cross-toolset
   leakage), with an opt-in, trust-gated per-request header override
   and redaction of any `sensitive: true` value from error output.
3. **`56170f9`** — `GeneratedTool.run` was blocking the whole event loop
   for up to 60s despite being `async def`. One-line `asyncio.to_thread`
   fix — multi-user support is the point of this PR, so a bug that
   serializes every user behind whoever called first belongs here too.
4. **`5ab692f`** — Inbound auth via `fastmcp`'s `JWTVerifier` against
   Keycloak's JWKS endpoint (not its DCR-oriented `KeycloakAuthProvider`
   — wrong shape for an internal server reached by one client that
   already holds its own token). Opt-in on `MCP_AUTH_KEYCLOAK_REALM_URL`
   alone.
5. **`994a8e8`** — `AUTHENTICATION.md`: the full reference, plain
   English + technical, for whoever maintains this later. Plus pointers
   from `ARCHITECTURE.md` and a short new section in `AGENTS.md`
   (written via the `agents-md` skill).

## Verified, not just tested in isolation

- A real (non-mocked) subprocess spawn through the new resolution path
  succeeds; a real Jira call with an injected `JIRA_PAT` reaches an
  actual network attempt (fails on DNS for a fake host, not a
  credential error) — proves the full chain, not just its pieces.
- A real running server: unauthenticated request against a
  Keycloak-configured server → genuine `401`; identical request against
  an unconfigured server → `200`, unchanged.
- A real concurrency test that fails at ~0.4s without the
  `asyncio.to_thread` fix and passes at ~0.2s with it — confirmed by
  reverting the fix and watching the test fail before restoring it.
- A real redaction bug (checking the wrong nesting level, so redaction
  silently did nothing) was caught by a test asserting the secret was
  actually absent from the payload, not just that the code ran.

258/258 tests passing (`mcp-server`: 68, `skills/jira`: 190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)